### PR TITLE
fix: defer review-triggered thinking bump until after follow-up

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,3 +16,4 @@
 - [x] Refactor Python project structure
 - [x] Add plumbum command execution dependency
 - [ ] Add higher-level orchestrator agent (see `ORCHESTRATOR_AGENT_PLAN.md`)
+- [x] Fix thinking bump on rebase conflict-only failures

--- a/src/orcha/workflow.py
+++ b/src/orcha/workflow.py
@@ -115,10 +115,9 @@ class OrchaFlow:
         post_review_state_hash = self.repository.state_hash(worktree_path)
         if pre_review_state_hash != post_review_state_hash:
             self.review_rejected_first_pass = True
-            followup_thinking_level = bump_thinking(followup_thinking_level)
             echo_out(
-                "orcha: review changed first pass; follow-up pi thinking bumped to "
-                f"{followup_thinking_level}"
+                "orcha: review changed first pass; follow-up pi will keep "
+                f"thinking {followup_thinking_level}"
             )
 
         post_review_commit_count = self.repository.count_commits(
@@ -386,7 +385,7 @@ class OrchaFlow:
             failure_context="while fixing CI",
         )
 
-        return self.bump_after_followup(followup_thinking_level)
+        return self.bump_after_review_rejected_followup(followup_thinking_level)
 
     def fix_rebase(
         self,
@@ -413,7 +412,7 @@ class OrchaFlow:
             failure_context="while resolving rebase",
         )
 
-        return self.bump_after_followup(followup_thinking_level)
+        return followup_thinking_level
 
     def resolve_repo_root(self) -> str:
         """Return the current git repository root or abort with Orcha's message."""
@@ -481,10 +480,16 @@ class OrchaFlow:
         )
         abort(pi_result.returncode)
 
-    def bump_after_followup(self, followup_thinking_level: str) -> str:
+    def bump_after_review_rejected_followup(self, followup_thinking_level: str) -> str:
         if not self.review_rejected_first_pass or not followup_thinking_level:
             return followup_thinking_level
-        return bump_thinking(followup_thinking_level)
+        bumped_level = bump_thinking(followup_thinking_level)
+        if bumped_level != followup_thinking_level:
+            echo_out(
+                "orcha: review-rejected follow-up completed; next pi thinking bumped to "
+                f"{bumped_level}"
+            )
+        return bumped_level
 
     def finish_successful_merge(
         self,

--- a/tests/test_orcha_flow.py
+++ b/tests/test_orcha_flow.py
@@ -502,7 +502,7 @@ def test_pr_setup_failures_return_error(
     assert message in process.stderr
 
 
-def test_ci_failure_invokes_followup_pi_and_retries_with_bumped_thinking(
+def test_first_ci_followup_keeps_thinking_after_review_changes(
     tmp_path: Path,
 ) -> None:
     state = base_state(
@@ -523,14 +523,39 @@ def test_ci_failure_invokes_followup_pi_and_retries_with_bumped_thinking(
         call for call in final_state["pi_calls"] if call["kind"] == "ci_fix"
     ]
     assert len(ci_fix_calls) == 1
-    assert ci_fix_calls[0]["thinking"] == "high"
+    assert ci_fix_calls[0]["thinking"] == "medium"
     assert "unit tests failed" in ci_fix_calls[0]["prompt"]
     assert "fix: address automated feedback" in final_state["commit_messages"]
     assert (
-        "review changed first pass; follow-up pi thinking bumped to high"
+        "review changed first pass; follow-up pi will keep thinking medium"
         in process.stdout
     )
+    assert "next pi thinking bumped to high" in process.stdout
     assert "orcha: PR attempt 2/3" in process.stdout
+
+
+def test_second_ci_followup_uses_bumped_thinking_after_review_changes(
+    tmp_path: Path,
+) -> None:
+    state = base_state(
+        tmp_path,
+        review_changes=True,
+        checks_sequence=[
+            {"status": 1, "out": "unit tests failed"},
+            {"status": 1, "out": "lint failed"},
+            {"status": 0, "out": "checks passed"},
+        ],
+    )
+
+    process, final_state = run_orcha(
+        tmp_path, ["feature/cool-stuff", "prompt"], state=state
+    )
+
+    assert_success(process)
+    ci_fix_calls = [
+        call for call in final_state["pi_calls"] if call["kind"] == "ci_fix"
+    ]
+    assert [call["thinking"] for call in ci_fix_calls] == ["medium", "high"]
 
 
 def test_ci_fix_regenerates_pr_and_squash_message(tmp_path: Path) -> None:
@@ -663,8 +688,35 @@ def test_rebase_conflict_invokes_pi_resolution(tmp_path: Path) -> None:
         call for call in final_state["pi_calls"] if call["kind"] == "rebase_fix"
     ]
     assert len(rebase_calls) == 1
+    assert rebase_calls[0]["thinking"] == "medium"
     assert "rebase onto origin/main is now in progress" in rebase_calls[0]["prompt"]
     assert "fix: resolve latest base changes" in final_state["commit_messages"]
+
+
+def test_rebase_conflict_after_review_changes_does_not_bump_thinking(
+    tmp_path: Path,
+) -> None:
+    state = base_state(
+        tmp_path,
+        review_changes=True,
+        merge_sequence=[
+            {"status": 1, "err": "conflict"},
+            {"status": 0, "out": "merged"},
+        ],
+        rebase_conflict_once=True,
+        dirty_after_rebase_fix=" M resolved\n",
+    )
+
+    process, final_state = run_orcha(
+        tmp_path, ["low", "feature/cool-stuff", "prompt"], state=state
+    )
+
+    assert_success(process)
+    rebase_calls = [
+        call for call in final_state["pi_calls"] if call["kind"] == "rebase_fix"
+    ]
+    assert [call["thinking"] for call in rebase_calls] == ["low"]
+    assert "next pi thinking bumped" not in process.stdout
 
 
 def test_rebase_still_in_progress_after_pi_stops(tmp_path: Path) -> None:


### PR DESCRIPTION
- Keep the first follow-up at the existing thinking level after review changes the initial solution.
- Bump thinking only after a review-rejected follow-up completes, so later CI retries can escalate.
- Leave rebase conflict resolution at the current thinking level to avoid conflict-only auto-bumps.
- Add regression coverage for CI retry and rebase-conflict thinking behavior.