### PR TITLE
feat: require review agents to update relevant docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ changes, retries when needed, squash-merges the PR, and cleans up the worktree.
 - Creates a clean branch in a sibling git worktree.
 - Runs either non-interactive `pi -p` or an interactive `pi` session.
 - Resumes automation after the interactive session exits.
-- Performs an automated review pass before committing.
+- Performs an automated review pass across committed and uncommitted work,
+  including a check that relevant documentation was updated for code,
+  behavior, workflow, configuration, and user-facing changes.
 - Generates the commit and PR title/body from the final reviewed work.
 - Verifies the generated commit title with `cog`.
 - Creates, updates, checks, retries, and squash-merges GitHub PRs with `gh`.
@@ -86,7 +88,9 @@ orcha session high feature/prototype-auth "explore auth UX options"
 4. Runs `pi --thinking <level> -p <prompt>`, or interactive `pi` in
    `session` mode.
 5. In `session` mode, waits until interactive `pi` exits.
-6. Runs a high-thinking `pi` review pass.
+6. Runs a high-thinking `pi` review pass over committed and uncommitted work
+   that fixes incomplete, unsafe, incorrect, or undocumented work and updates
+   relevant docs when code, workflow, configuration, or behavior changed.
 7. Runs a high-thinking `pi` message pass that writes JSON metadata under the
    worktree git directory only.
 8. Refuses to continue if the message pass changes the worktree, omits the

--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,7 @@
 - [x] Add Rich visual output to CLI
 - [x] Refactor Python project structure
 - [x] Add plumbum command execution dependency
+- [x] Add docs update enforcement to review agent
 - [ ] Add higher-level orchestrator agent (see `ORCHESTRATOR_AGENT_PLAN.md`)
 - [x] Fix thinking bump on rebase conflict-only failures
 - [x] Ensure review agent checks required tests

--- a/src/orcha/prompts.py
+++ b/src/orcha/prompts.py
@@ -38,11 +38,15 @@ def build_review_prompt(*, original_prompt: str, review_target: str) -> str:
 
     return (
         "Review the work for this original request and fix anything incomplete, "
-        "incorrect, unsafe, or not matching the request. "
+        "incorrect, unsafe, undocumented, or not matching the request. "
         f"{review_target} "
         "Check whether required tests were added for new functionality, or "
         "updated to reflect code changes when necessary. If behavior changed "
         "and test coverage is missing or stale, add or update the tests. "
+        "Ensure all relevant documentation was updated for any code, CLI, "
+        "workflow, behavior, configuration, or user-facing changes. If docs are "
+        "missing or stale, update them yourself instead of merely rejecting the "
+        "work, unless the needed documentation cannot be determined safely. "
         "If fixes are needed, apply them. You may commit fixes yourself or leave "
         "them unstaged; orcha will commit dirty changes afterward. Keep the worktree "
         f"clean when possible. Original request: {original_prompt}"

--- a/src/orcha/utils.py
+++ b/src/orcha/utils.py
@@ -35,6 +35,11 @@ def worktree_path_for(repo_root: str, branch: str) -> str:
 def review_target_for(base_rev: str, commit_count: int, dirty: bool) -> str:
     """Describe what the review pi pass should inspect."""
 
+    if commit_count > 0 and dirty:
+        return (
+            f"Review the commits in {base_rev}..HEAD and the uncommitted changes "
+            "in this worktree."
+        )
     if commit_count > 0:
         return f"Review the commits in {base_rev}..HEAD."
     if dirty:

--- a/tests/test_orcha_flow.py
+++ b/tests/test_orcha_flow.py
@@ -350,6 +350,11 @@ def test_session_pi_failure_stops_before_review(tmp_path: Path) -> None:
             "Review the commits in base123..HEAD.",
         ),
         (
+            {"commit_count": 2, "worktree_dirty": " M file.txt\n"},
+            "Review the commits in base123..HEAD and the uncommitted changes "
+            "in this worktree.",
+        ),
+        (
             {"commit_count": 0, "worktree_dirty": " M file.txt\n"},
             "Review the uncommitted changes in this worktree.",
         ),
@@ -380,6 +385,8 @@ def test_review_prompt_targets_commits_dirty_or_empty_work(
     assert expected_review_target in review_call["prompt"]
     assert "Check whether required tests were added" in review_call["prompt"]
     assert "add or update the tests" in review_call["prompt"]
+    assert "Ensure all relevant documentation was updated" in review_call["prompt"]
+    assert "update them yourself instead of merely rejecting" in review_call["prompt"]
     assert "Original request: original request" in review_call["prompt"]
 
 


### PR DESCRIPTION
- Expanded the review prompt to treat undocumented work as incomplete, update stale docs directly, and add or refresh tests when behavior changes.
- Updated review targeting so runs inspect both `base..HEAD` commits and dirty worktree changes when both exist.
- Adjusted review-triggered thinking bumps so CI follow-ups escalate after review fixes without unnecessarily bumping rebase-conflict handling.
- Documented the new review behavior in `README.md` and tracked the completed docs, tests, and thinking-bump work in `TODO.md`.