### PR TITLE
fix: keep merge retries from consuming agent attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ changes, retries when needed, squash-merges the PR, and cleans up the worktree.
 - Generates the commit and PR title/body from the final reviewed work.
 - Verifies the generated commit title with `cog`.
 - Creates, updates, checks, retries, and squash-merges GitHub PRs with `gh`.
-- Handles CI failure follow-ups and moved-base rebase retries.
+- Handles CI failure follow-ups and moved-base rebase retries without charging
+  agent attempts.
 - Uses Rich output for key status panels.
 
 ## Requirements
@@ -65,7 +66,7 @@ Arguments:
 | Argument | Default | Description |
 | --- | --- | --- |
 | `session` | off | Use interactive `pi` instead of one-shot `pi -p`; Orcha resumes after `pi` exits. |
-| `ATTEMPTS` | `3` | Maximum PR/check/merge attempts. Must be a positive integer. |
+| `ATTEMPTS` | `3` | Maximum agent rejection attempts. CI/check failures that require `pi` follow-up consume attempts; moved-base merge/rebase retries do not. Must be a positive integer. |
 | `THINKING` | `medium` | Initial `pi` thinking level: `low`, `medium`, `high`, or `xhigh`. |
 | `BRANCH` | required | New branch name to create. Must not already exist locally or on `origin`. |
 | `PROMPT...` | required for non-interactive; optional for `session` | Prompt passed to `pi -p`, or initial message for interactive `pi`. |
@@ -99,9 +100,11 @@ orcha session high feature/prototype-auth "explore auth UX options"
    the generated title/body, opens or updates a PR with the same title/body,
    then waits for GitHub checks.
 10. If checks fail, asks `pi` to fix them, commits that feedback, regenerates the
-    PR title/body from the updated diff, and retries.
+    PR title/body from the updated diff, and retries. These agent rejection
+    follow-ups consume `ATTEMPTS`.
 11. If squash merge fails because the base moved, rebases, regenerates the PR
-    title/body when the branch changes, and retries.
+    title/body when the branch changes, and retries without consuming
+    `ATTEMPTS`.
 12. On confirmed merge, pulls the default branch and removes the worktree and branch.
 
 ## Configuration
@@ -112,6 +115,7 @@ Orcha reads these optional environment variables:
 | --- | --- | --- |
 | `ORCHA_CHECKS_TIMEOUT_SECONDS` | `1800` | How long to wait for pending GitHub checks. |
 | `ORCHA_CHECKS_POLL_INTERVAL_SECONDS` | `10` | Delay between check polling attempts. |
+| `ORCHA_MERGE_RETRY_LIMIT` | `20` | Safety cap for moved-base merge/rebase retries that do not consume `ATTEMPTS`. |
 
 ## Development
 

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,9 @@
 - [x] Add plumbum command execution dependency
 - [x] Add docs update enforcement to review agent
 - [ ] Add higher-level orchestrator agent (see `ORCHESTRATOR_AGENT_PLAN.md`)
+- [x] Fix PR merge attempts counting only review rejects
 - [x] Fix thinking bump on rebase conflict-only failures
 - [x] Ensure review agent checks required tests
 - [x] Add session logging
 - [x] Review session logging implementation
+- [x] Review attempts counting changes and tests

--- a/src/orcha/workflow.py
+++ b/src/orcha/workflow.py
@@ -267,8 +267,11 @@ class OrchaFlow:
         message_state_hash = self.repository.state_hash(worktree_path)
         checks_timeout_seconds = env_int("ORCHA_CHECKS_TIMEOUT_SECONDS", 1800)
         checks_poll_interval_seconds = env_int("ORCHA_CHECKS_POLL_INTERVAL_SECONDS", 10)
+        merge_retry_limit = env_int("ORCHA_MERGE_RETRY_LIMIT", 20)
+        merge_retries = 0
+        attempt = 1
 
-        for attempt in range(1, parsed.max_attempts + 1):
+        while attempt <= parsed.max_attempts:
             if self.session_logger is not None:
                 self.session_logger.separator(
                     f"PR ATTEMPT {attempt}/{parsed.max_attempts}"
@@ -335,6 +338,8 @@ class OrchaFlow:
                         followup_thinking_level=followup_thinking_level,
                         worktree_path=worktree_path,
                     )
+                    attempt += 1
+                    merge_retries = 0
                     continue
 
             pr_head_oid = self.github.head_oid(parsed.branch, worktree_path)
@@ -373,16 +378,19 @@ class OrchaFlow:
                 )
                 return
 
-            if attempt >= parsed.max_attempts:
+            merge_retries += 1
+            if merge_retries > merge_retry_limit:
                 echo_err(
-                    f"orcha: github squash merge failed after {attempt} attempts; "
-                    f"leaving PR open: {pr_url}"
+                    "orcha: github squash merge failed after "
+                    f"{merge_retry_limit} merge retries; leaving PR open: {pr_url}"
                 )
                 abort(merge_result.returncode)
 
             echo_out(
                 "orcha: merge failed; rebasing onto latest "
-                f"origin/{default_branch} before retry"
+                f"origin/{default_branch} before retry "
+                f"({merge_retries}/{merge_retry_limit} merge retries; "
+                "agent attempts unchanged)"
             )
             self.runner.require(
                 ["git", "fetch", "origin", default_branch], cwd=worktree_path

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -548,6 +548,7 @@ def run_orcha(
                 state.get("checks_poll_interval_seconds", 0)
             ),
             "ORCHA_LOG_DIR": str(tmp_path / "logs"),
+            "ORCHA_MERGE_RETRY_LIMIT": str(state.get("merge_retry_limit", 20)),
         }
     )
     runner = CliRunner()

--- a/tests/test_orcha_flow.py
+++ b/tests/test_orcha_flow.py
@@ -758,6 +758,32 @@ def test_rebase_conflict_invokes_pi_resolution(tmp_path: Path) -> None:
     assert "fix: resolve latest base changes" in final_state["commit_messages"]
 
 
+def test_rebase_conflict_retry_does_not_consume_agent_attempt(
+    tmp_path: Path,
+) -> None:
+    state = base_state(
+        tmp_path,
+        merge_sequence=[
+            {"status": 1, "err": "conflict"},
+            {"status": 0, "out": "merged"},
+        ],
+        rebase_conflict_once=True,
+        dirty_after_rebase_fix=" M resolved\n",
+    )
+
+    process, final_state = run_orcha(
+        tmp_path, ["1", "feature/cool-stuff", "prompt"], state=state
+    )
+
+    assert_success(process)
+    rebase_calls = [
+        call for call in final_state["pi_calls"] if call["kind"] == "rebase_fix"
+    ]
+    assert final_state["merge_index"] == 2
+    assert len(rebase_calls) == 1
+    assert "agent attempts unchanged" in process.stdout
+
+
 def test_rebase_conflict_after_review_changes_does_not_bump_thinking(
     tmp_path: Path,
 ) -> None:
@@ -837,13 +863,35 @@ def test_merge_success_without_merged_at_leaves_pr_for_queue(tmp_path: Path) -> 
     assert "likely queued or auto-merge enabled" in process.stdout
 
 
-def test_merge_failure_after_last_attempt_leaves_pr_open(tmp_path: Path) -> None:
-    state = base_state(tmp_path, merge_sequence=[{"status": 9, "err": "merge blocked"}])
+def test_merge_retry_does_not_consume_agent_attempt(tmp_path: Path) -> None:
+    state = base_state(
+        tmp_path,
+        merge_sequence=[
+            {"status": 9, "err": "base branch moved"},
+            {"status": 0, "out": "merged"},
+        ],
+    )
+
+    process, final_state = run_orcha(
+        tmp_path, ["1", "feature/cool-stuff", "prompt"], state=state
+    )
+
+    assert_success(process)
+    assert final_state["merge_index"] == 2
+    assert "agent attempts unchanged" in process.stdout
+
+
+def test_merge_failure_after_retry_limit_leaves_pr_open(tmp_path: Path) -> None:
+    state = base_state(
+        tmp_path,
+        merge_sequence=[{"status": 9, "err": "merge blocked"}],
+        merge_retry_limit=1,
+    )
 
     process, _ = run_orcha(tmp_path, ["1", "feature/cool-stuff", "prompt"], state=state)
 
     assert process.returncode == 9
-    assert "github squash merge failed after 1 attempts" in process.stderr
+    assert "github squash merge failed after 1 merge retries" in process.stderr
 
 
 def test_cleanup_worktree_remove_failure_is_reported(tmp_path: Path) -> None:


### PR DESCRIPTION
- Separate GitHub squash-merge/rebase retries from agent attempt accounting so stale-base races no longer exhaust review/CI retry budget.
- Add `ORCHA_MERGE_RETRY_LIMIT` and retry progress output to cap repeated merge failures while keeping agent attempts unchanged.
- Add regression coverage for merge failures, rebase conflicts, combined dirty/commit review targets, and review-agent documentation expectations.
- Add session logging support and docs so agent runs, commands, output, and PR attempt boundaries are recorded for debugging.