### PR TITLE
feat: keep screen awake on macOS when configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ cleans up the worktree.
 - Handles CI failure follow-ups and moved-base rebase retries without charging
   agent attempts.
 - Uses Rich output for key status panels.
+- Optionally keeps the screen awake while pid runs on macOS.
 
 ## Requirements
 
@@ -128,8 +129,8 @@ Default config paths:
 Relative `XDG_CONFIG_HOME` values are ignored as required by the XDG Base
 Directory Specification.
 
-Only the agent command and launch behavior are configurable. Defaults are
-equivalent to:
+The agent command, launch behavior, and selected runtime behavior are
+configurable. Defaults are equivalent to:
 
 ```toml
 [agent]
@@ -140,6 +141,9 @@ default_thinking = "medium"
 review_thinking = "high"
 thinking_levels = ["low", "medium", "high", "xhigh"]
 label = "agent"
+
+[runtime]
+keep_screen_awake = false
 ```
 
 `command` may be an array of strings or a shell-style string.
@@ -149,6 +153,11 @@ may include `{thinking}`. `interactive_args` may include `{prompt}` and
 session prompt as a trailing argument. Those are the only supported template
 fields. pid never assumes a specific agent CLI internally; it only expands
 these templates.
+
+Set `runtime.keep_screen_awake = true` to keep the display awake while pid is
+running. This is currently implemented on macOS with the built-in `caffeinate`
+tool (`caffeinate -d -i`). Linux support is intentionally not enabled yet
+because pid does not assume a universal built-in Linux inhibitor.
 
 Example `pi` config:
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [x] Review keep-screen-awake implementation
 - [x] Move audit into hk.pkl
 - [x] Squash merge PR #6
 - [x] Add AI-authored commit and PR messages
@@ -22,6 +23,8 @@
 - [x] Add configurable agent harness
 - [x] Rename project to pid
 - [x] Rename repository and git remote to pid
+- [x] Add keep-screen-awake option for orcha
+- [ ] Implement Linux keep-awake support when pid can rely on a built-in inhibitor
 - [ ] Add higher-level orchestrator agent (see `ORCHESTRATOR_AGENT_PLAN.md`)
 - [x] Fix PR merge attempts counting only review rejects
 - [x] Fix thinking bump on rebase conflict-only failures

--- a/src/pid/config.py
+++ b/src/pid/config.py
@@ -61,10 +61,18 @@ class AgentConfig:
 
 
 @dataclass(frozen=True)
+class RuntimeConfig:
+    """Configured pid runtime behavior."""
+
+    keep_screen_awake: bool = False
+
+
+@dataclass(frozen=True)
 class PIDConfig:
     """Top-level pid config."""
 
     agent: AgentConfig = field(default_factory=AgentConfig)
+    runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
 
 
 def default_config_path() -> Path:
@@ -110,13 +118,21 @@ def load_config(path: Path | None = None) -> PIDConfig:
 
 
 def parse_config(data: dict[str, Any], path: Path) -> PIDConfig:
-    unknown_top = set(data) - {"agent"}
+    unknown_top = set(data) - {"agent", "runtime"}
     if unknown_top:
         fail_config(path, f"unknown top-level key: {sorted(unknown_top)[0]}")
 
     agent_data = data.get("agent", {})
     if not isinstance(agent_data, dict):
         fail_config(path, "[agent] must be a table")
+
+    runtime_data = data.get("runtime", {})
+    if not isinstance(runtime_data, dict):
+        fail_config(path, "[runtime] must be a table")
+    allowed_runtime = {"keep_screen_awake"}
+    unknown_runtime = set(runtime_data) - allowed_runtime
+    if unknown_runtime:
+        fail_config(path, f"unknown [runtime] key: {sorted(unknown_runtime)[0]}")
 
     allowed_agent = {
         "command",
@@ -164,6 +180,11 @@ def parse_config(data: dict[str, Any], path: Path) -> PIDConfig:
         "agent.review_thinking",
     )
     label = string_value(agent_data.get("label", default.label), path, "agent.label")
+    keep_screen_awake = bool_value(
+        runtime_data.get("keep_screen_awake", False),
+        path,
+        "runtime.keep_screen_awake",
+    )
 
     if not command:
         fail_config(path, "agent.command must not be empty")
@@ -199,8 +220,15 @@ def parse_config(data: dict[str, Any], path: Path) -> PIDConfig:
             review_thinking=review_thinking,
             thinking_levels=thinking_levels,
             label=label,
-        )
+        ),
+        runtime=RuntimeConfig(keep_screen_awake=keep_screen_awake),
     )
+
+
+def bool_value(value: Any, path: Path, key: str) -> bool:
+    if not isinstance(value, bool):
+        fail_config(path, f"{key} must be a boolean")
+    return value
 
 
 def string_value(value: Any, path: Path, key: str) -> str:

--- a/src/pid/keepawake.py
+++ b/src/pid/keepawake.py
@@ -1,0 +1,69 @@
+"""Keep-screen-awake helpers for pid."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+from pid.errors import abort
+from pid.output import echo_err, echo_out
+from pid.session_logging import SessionLogger
+
+
+class KeepAwake:
+    """Manage an optional OS-level keep-awake helper."""
+
+    def __init__(self, *, enabled: bool, logger: SessionLogger | None = None) -> None:
+        self.enabled = enabled
+        self.logger = logger
+        self.process: subprocess.Popen[Any] | None = None
+
+    def start(self) -> None:
+        """Start the platform keep-awake process when configured."""
+
+        if not self.enabled:
+            return
+
+        if sys.platform != "darwin":
+            echo_err(
+                "pid: runtime.keep_screen_awake is only implemented on macOS for now"
+            )
+            abort(2)
+
+        if shutil.which("caffeinate") is None:
+            echo_err("pid: runtime.keep_screen_awake requires caffeinate on PATH")
+            abort(2)
+
+        args = ["caffeinate", "-d", "-i"]
+        try:
+            self.process = subprocess.Popen(
+                args,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError as error:
+            echo_err(f"pid: could not start caffeinate: {error}")
+            abort(2)
+        if self.logger is not None:
+            self.logger.event("keep-screen-awake started: caffeinate -d -i")
+        echo_out("pid: keeping screen awake with caffeinate")
+
+    def stop(self) -> None:
+        """Stop any active keep-awake process."""
+
+        if self.process is None:
+            return
+
+        process = self.process
+        self.process = None
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+        if self.logger is not None:
+            self.logger.event("keep-screen-awake stopped")

--- a/src/pid/workflow.py
+++ b/src/pid/workflow.py
@@ -10,6 +10,7 @@ from pid.commands import CommandRunner, require_command
 from pid.config import PIDConfig
 from pid.errors import PIDAbort, abort
 from pid.github import GitHub
+from pid.keepawake import KeepAwake
 from pid.messages import parse_commit_message
 from pid.models import CommitMessage, ParsedArgs
 from pid.output import (
@@ -45,6 +46,7 @@ class PIDFlow:
         self.github = GitHub(self.runner)
         self.review_rejected_first_pass = False
         self.session_logger: SessionLogger | None = None
+        self.keep_awake: KeepAwake | None = None
 
     def run(self, argv: list[str]) -> int:
         exit_code = 0
@@ -60,6 +62,9 @@ class PIDFlow:
                 )
             raise
         finally:
+            if self.keep_awake is not None:
+                self.keep_awake.stop()
+                self.keep_awake = None
             if self.session_logger is not None:
                 self.session_logger.event(f"exit code: {exit_code}")
                 self.session_logger.close()
@@ -74,6 +79,7 @@ class PIDFlow:
             thinking_levels=self.config.agent.thinking_levels,
         )
         self.start_session_logging(argv)
+        self.start_keep_awake()
         self.log_parsed_args(parsed)
         followup_thinking_level = parsed.thinking_level
 
@@ -201,6 +207,15 @@ class PIDFlow:
         set_session_logger(self.session_logger)
         self.runner.set_logger(self.session_logger)
         echo_out(f"pid: session log: {self.session_logger.path}")
+
+    def start_keep_awake(self) -> None:
+        """Start the optional keep-awake helper for a valid pid run."""
+
+        self.keep_awake = KeepAwake(
+            enabled=self.config.runtime.keep_screen_awake,
+            logger=self.session_logger,
+        )
+        self.keep_awake.start()
 
     def log_parsed_args(self, parsed: ParsedArgs) -> None:
         """Record parsed CLI args in the session log."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,20 @@ def test_default_missing_config_path_uses_defaults(
     assert load_config() == config_module.PIDConfig()
 
 
+def test_runtime_keep_screen_awake_defaults_off(tmp_path: Path) -> None:
+    loaded = parse_config({}, tmp_path / "config.toml")
+
+    assert loaded.runtime.keep_screen_awake is False
+
+
+def test_runtime_keep_screen_awake_can_be_enabled(tmp_path: Path) -> None:
+    loaded = parse_config(
+        {"runtime": {"keep_screen_awake": True}}, tmp_path / "config.toml"
+    )
+
+    assert loaded.runtime.keep_screen_awake is True
+
+
 def test_agent_command_accepts_shell_style_string(tmp_path: Path) -> None:
     config = parse_config(
         {
@@ -85,6 +99,18 @@ def test_agent_command_accepts_shell_style_string(tmp_path: Path) -> None:
         "--message",
         "do work",
     ]
+
+
+def test_invalid_runtime_config_is_rejected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(PIDAbort) as exc_info:
+        parse_config(
+            {"runtime": {"keep_screen_awake": "yes"}}, tmp_path / "config.toml"
+        )
+
+    assert exc_info.value.code == 2
+    assert "runtime.keep_screen_awake must be a boolean" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pid_flow.py
+++ b/tests/test_pid_flow.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import pytest
 
+import pid.keepawake as keepawake_module
+from pid.errors import PIDAbort
 from tests.fakes import (
     assert_success,
     base_state,
@@ -67,6 +69,97 @@ def test_invalid_branch_name_stops_before_repo_setup(tmp_path: Path) -> None:
     assert "pid: invalid branch name: bad branch" in process.stderr
     assert calls(final_state, "git", "check-ref-format")
     assert not calls(final_state, "git", "rev-parse", "--show-toplevel")
+
+
+def test_keep_screen_awake_starts_caffeinate_on_macos(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    popen_calls: list[list[str]] = []
+
+    class FakeProcess:
+        terminated = False
+        killed = False
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def wait(self, timeout: int | None = None) -> None:
+            return None
+
+        def kill(self) -> None:
+            self.killed = True
+
+    fake_process = FakeProcess()
+
+    def fake_popen(args: list[str], **_kwargs: object) -> FakeProcess:
+        popen_calls.append(args)
+        return fake_process
+
+    monkeypatch.setattr(keepawake_module.sys, "platform", "darwin")
+    monkeypatch.setattr(keepawake_module.shutil, "which", lambda command: command)
+    monkeypatch.setattr(keepawake_module.subprocess, "Popen", fake_popen)
+
+    guard = keepawake_module.KeepAwake(enabled=True)
+    guard.start()
+    guard.stop()
+
+    assert popen_calls == [["caffeinate", "-d", "-i"]]
+    assert fake_process.terminated is True
+    assert "keeping screen awake with caffeinate" in capsys.readouterr().out
+
+
+def test_keep_screen_awake_reports_caffeinate_launch_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_popen(_args: list[str], **_kwargs: object) -> None:
+        raise OSError("boom")
+
+    monkeypatch.setattr(keepawake_module.sys, "platform", "darwin")
+    monkeypatch.setattr(keepawake_module.shutil, "which", lambda command: command)
+    monkeypatch.setattr(keepawake_module.subprocess, "Popen", fake_popen)
+
+    guard = keepawake_module.KeepAwake(enabled=True)
+    with pytest.raises(PIDAbort) as exc_info:
+        guard.start()
+
+    assert exc_info.value.code == 2
+    assert "could not start caffeinate: boom" in capsys.readouterr().err
+
+
+def test_keep_screen_awake_rejects_unsupported_linux(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(keepawake_module.sys, "platform", "linux")
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("[runtime]\nkeep_screen_awake = true\n")
+
+    process, _ = run_pid(
+        tmp_path,
+        ["--config", str(config_path), "feature/cool-stuff", "prompt"],
+        commands=(),
+    )
+
+    assert process.returncode == 2
+    assert "keep_screen_awake is only implemented on macOS" in process.stderr
+
+
+def test_keep_screen_awake_does_not_start_for_usage_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(keepawake_module.sys, "platform", "linux")
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("[runtime]\nkeep_screen_awake = true\n")
+
+    process, _ = run_pid(tmp_path, ["--config", str(config_path)], commands=())
+
+    assert_success(process)
+    assert process.stdout == (
+        "usage: pid [session] [ATTEMPTS] [THINKING] BRANCH [PROMPT...]\n"
+    )
+    assert process.stderr == ""
 
 
 def test_generated_commit_title_is_validated_with_cog(tmp_path: Path) -> None:


### PR DESCRIPTION
- Add an opt-in `runtime.keep_screen_awake` config flag, defaulting to `false`, with validation for invalid runtime values.
- Start and stop a macOS `caffeinate -d -i` helper around valid pid runs so the display stays awake while work is active.
- Reject enabled keep-awake mode on unsupported platforms for now and record a TODO for future Linux support.
- Document the new runtime option and cover config parsing, macOS lifecycle, failure handling, and usage-only behavior with tests.