### PR TITLE
test: expand edge-case coverage and enforce coverage gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Use `mise` tasks rather than invoking tools directly:
 | --- | --- |
 | `mise run lint` | Run hk-managed checks. |
 | `mise run fix` | Run hk-managed formatters and fixers. |
-| `mise run test` | Run the pytest suite. |
+| `mise run test` | Run pytest with coverage reporting and a 95% coverage gate. |
 | `mise run build` | Build the Python package. |
 | `mise run check` | Run all project checks. |
 | `mise run release:bump` | Bump the package version. |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Install from a local checkout:
 uv tool install .
 ```
 
-For development, use `mise` from the repository root:
+For development, use `mise` from the repository root. `mise run test` runs
+pytest with the repository coverage gate:
 
 ```sh
 mise trust
@@ -224,7 +225,8 @@ pid reads these optional environment variables:
 
 ## Development
 
-This repository uses `mise` for tools and tasks.
+This repository uses `mise` for tools and tasks. The test task runs pytest with
+coverage reporting and fails below 95% total coverage.
 
 ```sh
 mise trust

--- a/TODO.md
+++ b/TODO.md
@@ -34,3 +34,5 @@
 - [x] Review attempts counting changes and tests
 - [x] Analyze Docker AI Sandboxes fit
 - [x] Write sbx implementation/cleanup plan
+- [x] Add edge-case tests and improve coverage
+- [x] Review edge-case test coverage work

--- a/mise.toml
+++ b/mise.toml
@@ -38,9 +38,9 @@ depends = ["install"]
 run = "hk check --all"
 
 [tasks.test]
-description = "Run test suite"
+description = "Run test suite with coverage gate"
 depends = ["install"]
-run = "uv run pytest"
+run = "uv run pytest --cov=pid --cov-report=term-missing --cov-fail-under=95"
 
 [tasks.build]
 description = "Build project package"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pid = "pid.cli:app"
 dev = [
   "hypothesis>=6.152.3",
   "pytest>=9.0.3",
+  "pytest-cov>=7.0.0",
 ]
 
 [build-system]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pid.errors import PIDAbort
+from pid.messages import MESSAGE_BODY_LIMIT, MESSAGE_TITLE_LIMIT, parse_commit_message
+from pid.models import CommitMessage
+
+
+def test_parse_commit_message_strips_valid_title_and_body() -> None:
+    assert parse_commit_message(
+        json.dumps({"title": "  feat: useful thing  ", "body": "\n- Done.\n"})
+    ) == CommitMessage("feat: useful thing", "- Done.")
+
+
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    [
+        ("[]", "must be a JSON object"),
+        (json.dumps({"title": "   ", "body": "body"}), "title is empty"),
+        (
+            json.dumps({"title": "feat: one\nline", "body": "body"}),
+            "title must be one line",
+        ),
+        (
+            json.dumps({"title": "x" * (MESSAGE_TITLE_LIMIT + 1), "body": "body"}),
+            f"title exceeds {MESSAGE_TITLE_LIMIT} characters",
+        ),
+        (json.dumps({"title": "feat: ok", "body": "   "}), "body is empty"),
+        (
+            json.dumps({"title": "feat: ok", "body": "x" * (MESSAGE_BODY_LIMIT + 1)}),
+            f"body exceeds {MESSAGE_BODY_LIMIT} characters",
+        ),
+        (json.dumps({"title": "feat: \u0000", "body": "body"}), "contains a NUL byte"),
+        (json.dumps({"title": 123, "body": "body"}), "field 'title' must be a string"),
+        (
+            json.dumps({"title": "feat: ok", "body": None}),
+            "field 'body' must be a string",
+        ),
+    ],
+)
+def test_parse_commit_message_rejects_malformed_metadata(
+    raw: str, message: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(PIDAbort) as exc_info:
+        parse_commit_message(raw)
+
+    assert exc_info.value.code == 1
+    assert message in capsys.readouterr().err

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import io
+import runpy
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+import pid
+import pid.config as config_module
+import pid.cli as cli_module
+from pid.commands import CommandRunner, require_command
+from pid.config import AgentConfig, load_config, parse_config
+from pid.errors import PIDAbort
+from pid.models import CommandResult
+from pid.output import (
+    get_session_logger,
+    set_session_logger,
+    write_collected,
+    write_command_output,
+)
+from pid.parsing import bump_thinking, parse_args
+from pid.repository import Repository
+from pid.session_logging import CommandLogHandle, SessionLogger
+from pid.utils import env_int, has_output, worktree_path_for
+from pid.workflow import PIDFlow
+
+
+def test_package_version_falls_back_when_metadata_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_version(_name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError("pid")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(importlib.metadata, "version", missing_version)
+        assert importlib.reload(pid).__version__ == "0.0.0"
+
+    importlib.reload(pid)
+
+
+def test_module_entrypoint_invokes_cli_app(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_app() -> None:
+        calls.append("called")
+
+    monkeypatch.setattr(cli_module, "app", fake_app)
+
+    runpy.run_module("pid.__main__", run_name="__main__")
+
+    assert calls == ["called"]
+
+
+def test_agent_config_appends_interactive_prompt_when_template_has_no_prompt() -> None:
+    config = AgentConfig(command=("agent",), interactive_args=("session",))
+
+    assert config.interactive_command(prompt="look around", thinking="high") == [
+        "agent",
+        "session",
+        "look around",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("data", "message"),
+    [
+        ({"unexpected": {}}, "unknown top-level key: unexpected"),
+        ({"agent": []}, "[agent] must be a table"),
+        ({"agent": {"unexpected": True}}, "unknown [agent] key: unexpected"),
+        ({"agent": {"command": []}}, "agent.command must not be empty"),
+        ({"agent": {"command": [""]}}, "agent.command executable must not be empty"),
+        (
+            {"agent": {"non_interactive_args": []}},
+            "agent.non_interactive_args must not be empty",
+        ),
+        ({"agent": {"thinking_levels": []}}, "agent.thinking_levels must not be empty"),
+        (
+            {"agent": {"thinking_levels": ["low", ""]}},
+            "agent.thinking_levels must not contain empty strings",
+        ),
+        ({"agent": {"label": ""}}, "agent.label must not be empty"),
+        (
+            {"agent": {"default_thinking": "huge"}},
+            "agent.default_thinking must be in agent.thinking_levels",
+        ),
+        (
+            {"agent": {"review_thinking": "huge"}},
+            "agent.review_thinking must be in agent.thinking_levels",
+        ),
+        (
+            {"agent": {"non_interactive_args": "-p {prompt}"}},
+            "agent.non_interactive_args must be an array of strings",
+        ),
+        ({"agent": {"interactive_args": 1}}, "agent.interactive_args must be an array"),
+        (
+            {"agent": {"interactive_args": ["ok", 1]}},
+            "agent.interactive_args must contain only strings",
+        ),
+        (
+            {"agent": {"non_interactive_args": ["{prompt", "{prompt}"]}},
+            "invalid placeholder syntax",
+        ),
+        (
+            {"agent": {"non_interactive_args": ["{0}", "{prompt}"]}},
+            "unsupported placeholder {0}",
+        ),
+    ],
+)
+def test_parse_config_rejects_edge_cases(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    data: dict[str, Any],
+    message: str,
+) -> None:
+    with pytest.raises(PIDAbort) as exc_info:
+        parse_config(data, tmp_path / "config.toml")
+
+    assert exc_info.value.code == 2
+    assert message in capsys.readouterr().err
+
+
+def test_load_config_reports_invalid_toml(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text("[agent\n", encoding="utf-8")
+
+    with pytest.raises(PIDAbort) as exc_info:
+        load_config(path)
+
+    assert exc_info.value.code == 2
+    assert "invalid config TOML" in capsys.readouterr().err
+
+
+def test_load_config_reports_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "config.toml"
+    path.touch()
+
+    def raise_oserror(self: Path, *args: object, **kwargs: object) -> str:
+        raise OSError("boom")
+
+    monkeypatch.setattr(config_module.Path, "read_text", raise_oserror)
+
+    with pytest.raises(PIDAbort) as exc_info:
+        load_config(path)
+
+    assert exc_info.value.code == 2
+    assert "could not read config" in capsys.readouterr().err
+
+
+def test_load_config_reports_utf8_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "config.toml"
+    path.touch()
+
+    def raise_unicode(self: Path, *args: object, **kwargs: object) -> str:
+        raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+
+    monkeypatch.setattr(config_module.Path, "read_text", raise_unicode)
+
+    with pytest.raises(PIDAbort) as exc_info:
+        load_config(path)
+
+    assert exc_info.value.code == 2
+    assert "config is not valid UTF-8" in capsys.readouterr().err
+
+
+def test_command_runner_reports_missing_commands(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runner = CommandRunner()
+
+    result = runner.run(["definitely-missing-pid-command"])
+
+    assert result == CommandResult(
+        127, "", "pid: command not found: definitely-missing-pid-command\n"
+    )
+    with pytest.raises(PIDAbort) as exc_info:
+        runner.output(["definitely-missing-pid-command"])
+    assert exc_info.value.code == 127
+    assert "command not found" in capsys.readouterr().err
+
+
+def test_command_runner_quiet_output_suppresses_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(PIDAbort):
+        CommandRunner().output(["definitely-missing-pid-command"], quiet=True)
+
+    assert capsys.readouterr().err == ""
+
+
+def test_command_runner_run_interactive_missing_command() -> None:
+    result = CommandRunner().run_interactive(["definitely-missing-pid-command"])
+
+    assert result.returncode == 127
+    assert "command not found" in result.stderr
+
+
+def test_command_runner_require_quiet_suppresses_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(PIDAbort) as exc_info:
+        CommandRunner().require(["definitely-missing-pid-command"], quiet=True)
+
+    assert exc_info.value.code == 127
+    assert capsys.readouterr().err == ""
+
+
+def test_require_command_reports_missing_executable(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("pid.commands.shutil.which", lambda _command: None)
+
+    with pytest.raises(PIDAbort) as exc_info:
+        require_command("tool", "tool missing")
+
+    assert exc_info.value.code == 1
+    assert "tool missing" in capsys.readouterr().err
+
+
+def test_output_helpers_preserve_newline_behavior(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    set_session_logger(None)
+    assert get_session_logger() is None
+    write_collected("no newline", stream=sys.stdout)
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    write_command_output(CommandResult(1, "out", "err\n"))
+
+    captured = capsys.readouterr()
+    assert captured.out == "no newline\n"
+    assert stdout.getvalue() == "out\n"
+    assert stderr.getvalue() == "err\n"
+
+
+def test_parse_args_session_help(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(PIDAbort) as exc_info:
+        parse_args(["session", "--help"])
+
+    assert exc_info.value.code == 0
+    assert "usage: pid session" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("level", "levels", "expected"),
+    [
+        ("unknown", ("low", "high"), "unknown"),
+        ("high", ("low", "high"), "high"),
+        ("low", ("low", "high"), "high"),
+    ],
+)
+def test_bump_thinking_boundaries(
+    level: str, levels: tuple[str, ...], expected: str
+) -> None:
+    assert bump_thinking(level, levels) == expected
+
+
+def test_utils_env_int_and_path_helpers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("PID_TEST_INT", raising=False)
+    assert env_int("PID_TEST_INT", 7) == 7
+    monkeypatch.setenv("PID_TEST_INT", "not-int")
+    assert env_int("PID_TEST_INT", 7) == 7
+    monkeypatch.setenv("PID_TEST_INT", "11")
+    assert env_int("PID_TEST_INT", 7) == 11
+    assert has_output(" \n\t") is False
+    assert has_output(" x ") is True
+    assert worktree_path_for(str(tmp_path / "repo"), "feat/foo") == str(
+        tmp_path / "repo-feat-foo"
+    )
+
+
+class StateHashRunner:
+    def __init__(self, outputs: dict[tuple[str, ...], str]) -> None:
+        self.outputs = outputs
+
+    def output(self, args: list[str], *, cwd: str | Path) -> str:
+        return self.outputs[tuple(args)]
+
+
+def test_repository_state_hash_includes_untracked_file_content(tmp_path: Path) -> None:
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / "tracked.txt").write_text("new file", encoding="utf-8")
+    runner = StateHashRunner(
+        {
+            ("git", "rev-parse", "HEAD"): "abc123\n",
+            (
+                "git",
+                "status",
+                "--porcelain",
+                "--untracked-files=all",
+            ): "?? tracked.txt\n?? dir\n",
+            ("git", "diff", "--binary", "--no-ext-diff"): "",
+            ("git", "diff", "--cached", "--binary", "--no-ext-diff"): "",
+            ("git", "ls-files", "--others", "--exclude-standard"): "tracked.txt\ndir\n",
+        }
+    )
+    repository = Repository(cast(CommandRunner, runner))
+
+    first_hash = repository.state_hash(str(worktree))
+    (worktree / "tracked.txt").write_text("changed", encoding="utf-8")
+    second_hash = repository.state_hash(str(worktree))
+
+    assert first_hash != second_hash
+
+
+class UnclosedStringIO(io.StringIO):
+    def close(self) -> None:
+        pass
+
+
+def test_session_logger_closes_open_step_once() -> None:
+    stream = UnclosedStringIO()
+    logger = SessionLogger(Path("session.log"), stream)
+
+    logger.step_start("one")
+    logger.step_start("two")
+    logger.output_block("BLOCK", "value")
+    logger.close()
+    logger.close()
+
+    log = stream.getvalue()
+    assert "STEP END: one" in log
+    assert "STEP END: two" in log
+    assert log.count("SESSION END") == 1
+    assert "BLOCK\nvalue\n" in log
+
+
+def test_session_logger_records_command_exception() -> None:
+    stream = io.StringIO()
+    logger = SessionLogger(Path("session.log"), stream)
+
+    logger.command_exception(CommandLogHandle(4, 0.0), RuntimeError("boom"))
+
+    assert "COMMAND EXCEPTION #4" in stream.getvalue()
+    assert "RuntimeError: boom" in stream.getvalue()
+
+
+def test_pid_flow_disables_session_logging_when_log_creation_fails(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        "pid.workflow.SessionLogger.create",
+        lambda _argv: (_ for _ in ()).throw(OSError("no log")),
+    )
+    flow = PIDFlow()
+
+    flow.start_session_logging(["feature/x", "prompt"])
+    flow.log_parsed_args(parse_args(["feature/x", "prompt"]))
+
+    assert flow.session_logger is None
+    assert "session logging disabled: no log" in capsys.readouterr().err

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,45 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
 name = "hypothesis"
 version = "6.152.3"
 source = { registry = "https://pypi.org/simple" }
@@ -75,6 +114,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pid"
 version = "0.3.0"
 source = { editable = "." }
@@ -88,6 +136,7 @@ dependencies = [
 dev = [
     { name = "hypothesis" },
     { name = "pytest" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -101,15 +150,7 @@ requires-dist = [
 dev = [
     { name = "hypothesis", specifier = ">=6.152.3" },
     { name = "pytest", specifier = ">=9.0.3" },
-]
-
-[[package]]
-name = "packaging"
-version = "26.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
 
 [[package]]
@@ -156,6 +197,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Added pytest-cov and updated the mise test task to report coverage and fail below 95%.
- Expanded edge-case tests for config validation, commit message metadata parsing, CLI parsing, command execution, output helpers, repository hashing, and session logging.
- Added coverage for the macOS keep-screen-awake runtime option, including config parsing, caffeinate lifecycle, launch failures, and unsupported-platform behavior.
- Updated README and CONTRIBUTING docs to describe the coverage gate and keep-screen-awake configuration.