### PR TITLE
feat: add interactive prompts for missing CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ mise run test
 ## Usage
 
 ```sh
+pid
 pid [ATTEMPTS] [THINKING] BRANCH PROMPT...
 pid session [ATTEMPTS] [THINKING] BRANCH [PROMPT...]
 ```
@@ -83,12 +84,32 @@ Arguments:
 Examples:
 
 ```sh
+pid
 pid feature/add-readme "add project docs"
 pid 2 high fix/repair-ci "fix failing tests"
 pid docs/update-install update installation instructions
 pid session feature/explore-api
 pid session high feature/prototype-auth "explore auth UX options"
 ```
+
+### Interactive argument prompts
+
+When stdin is a TTY, pid fills missing values interactively before starting the
+workflow:
+
+- `pid` prompts for attempts, thinking level, branch, and prompt. Attempts and
+  thinking level show their configured defaults; press Enter to accept them.
+- `pid feature/some-feature` uses the supplied branch and prompts only for the
+  prompt.
+- `pid high` uses the supplied thinking level and prompts for branch and
+  prompt.
+- `pid session` prompts for branch only because the initial session prompt is
+  optional.
+- pid shows current values before each prompt and asks for final confirmation
+  before continuing.
+
+If stdin is not a TTY, pid keeps non-interactive behavior: missing required
+arguments print usage or validation errors instead of blocking for input.
 
 ## How it works
 

--- a/src/pid/cli.py
+++ b/src/pid/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Annotated
 
@@ -9,6 +10,7 @@ import typer
 
 from pid.config import load_config
 from pid.errors import PIDAbort
+from pid.interactive import resolve_interactive_args
 from pid.workflow import run_pid
 
 APP_CONTEXT = {
@@ -48,6 +50,11 @@ def main(
     raw_args = [*(args or []), *ctx.args]
     try:
         loaded_config = load_config(config)
+        resolved_args = (
+            resolve_interactive_args(raw_args, loaded_config)
+            if sys.stdin.isatty()
+            else raw_args
+        )
     except PIDAbort as error:
         raise typer.Exit(error.code) from error
-    raise typer.Exit(run_pid(raw_args, config=loaded_config))
+    raise typer.Exit(run_pid(resolved_args, config=loaded_config))

--- a/src/pid/interactive.py
+++ b/src/pid/interactive.py
@@ -1,0 +1,139 @@
+"""Interactive argument collection for pid."""
+
+from __future__ import annotations
+
+import re
+
+import click
+
+from pid.config import PIDConfig
+
+
+def resolve_interactive_args(argv: list[str], config: PIDConfig) -> list[str]:
+    """Prompt for missing pid arguments, then return fish-compatible argv."""
+
+    if argv and argv[0] in {"--help", "-h"}:
+        return argv
+
+    original = list(argv)
+    args = list(argv)
+    resolved: list[str] = []
+    prompted = False
+    prompt_all_defaults = not args
+    interactive = False
+
+    if args and args[0] == "session":
+        interactive = True
+        resolved.append(args.pop(0))
+        if args and args[0] in {"--help", "-h"}:
+            return original
+
+    attempts = "3"
+    if args and re.fullmatch(r"[0-9]+", args[0]):
+        if re.fullmatch(r"[1-9][0-9]*", args[0]) is None:
+            return original
+        attempts = args.pop(0)
+        resolved.append(attempts)
+    elif prompt_all_defaults:
+        attempts = _prompt_attempts(
+            attempts, _values(attempts, config.agent.default_thinking, "", "")
+        )
+        resolved.append(attempts)
+        prompted = True
+
+    thinking = config.agent.default_thinking
+    if args and args[0] in config.agent.thinking_levels:
+        thinking = args.pop(0)
+        resolved.append(thinking)
+    elif prompt_all_defaults:
+        thinking = _prompt_thinking(
+            thinking,
+            config.agent.thinking_levels,
+            _values(attempts, thinking, "", ""),
+        )
+        resolved.append(thinking)
+        prompted = True
+
+    branch = ""
+    if args:
+        branch = args.pop(0)
+        resolved.append(branch)
+    else:
+        branch = _prompt_required(
+            "Branch",
+            example="feature/short-description",
+            values=_values(attempts, thinking, branch, ""),
+        )
+        resolved.append(branch)
+        prompted = True
+
+    prompt = " ".join(args)
+    if prompt:
+        resolved.extend(args)
+    elif not interactive:
+        prompt = _prompt_required(
+            "Prompt",
+            example="Add OAuth login and tests",
+            values=_values(attempts, thinking, branch, prompt),
+        )
+        resolved.extend(prompt.split())
+        prompted = True
+
+    if prompted:
+        _show_values(_values(attempts, thinking, branch, prompt))
+        if not click.confirm("Continue with these values?", default=True):
+            raise click.Abort()
+
+    return resolved
+
+
+def _values(attempts: str, thinking: str, branch: str, prompt: str) -> dict[str, str]:
+    return {
+        "attempts": attempts or "(default 3)",
+        "thinking": thinking or "(default)",
+        "branch": branch or "(unset)",
+        "prompt": prompt or "(unset)",
+    }
+
+
+def _show_values(values: dict[str, str]) -> None:
+    click.echo("\npid values:")
+    for key, value in values.items():
+        click.echo(f"  {key}: {value}")
+    click.echo("")
+
+
+def _prompt_attempts(default: str, values: dict[str, str]) -> str:
+    while True:
+        _show_values(values)
+        value = click.prompt(
+            "Attempts (positive integer)", default=default, show_default=True
+        )
+        if re.fullmatch(r"[1-9][0-9]*", value):
+            return value
+        click.echo("Enter a positive integer, e.g. 3.", err=True)
+
+
+def _prompt_thinking(
+    default: str, thinking_levels: tuple[str, ...], values: dict[str, str]
+) -> str:
+    levels = ", ".join(thinking_levels)
+    while True:
+        _show_values(values)
+        value = click.prompt(
+            f"Thinking level ({levels})", default=default, show_default=True
+        )
+        if value in thinking_levels:
+            return value
+        click.echo(f"Choose one of: {levels}.", err=True)
+
+
+def _prompt_required(label: str, *, example: str, values: dict[str, str]) -> str:
+    while True:
+        _show_values(values)
+        value = click.prompt(
+            f"{label} (example: {example})", default="", show_default=False
+        )
+        if value.strip():
+            return value.strip()
+        click.echo(f"{label} is required. Example: {example}", err=True)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -8,15 +8,17 @@ import sys
 from pathlib import Path
 from typing import Any, cast
 
+import click
 import pytest
 
 import pid
 import pid.config as config_module
 import pid.cli as cli_module
 from pid.commands import CommandRunner, require_command
-from pid.config import AgentConfig, load_config, parse_config
+from pid.config import AgentConfig, PIDConfig, load_config, parse_config
 from pid.errors import PIDAbort
 from pid.models import CommandResult
+from pid.interactive import resolve_interactive_args
 from pid.output import (
     get_session_logger,
     set_session_logger,
@@ -244,6 +246,136 @@ def test_output_helpers_preserve_newline_behavior(
     assert captured.out == "no newline\n"
     assert stdout.getvalue() == "out\n"
     assert stderr.getvalue() == "err\n"
+
+
+def test_resolve_interactive_args_prompts_all_values_when_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    answers = iter(["3", "high", "feature/new-cli", "add guided prompts"])
+    monkeypatch.setattr("pid.interactive.click.prompt", lambda *_, **__: next(answers))
+    monkeypatch.setattr("pid.interactive.click.confirm", lambda *_, **__: True)
+
+    assert resolve_interactive_args([], PIDConfig()) == [
+        "3",
+        "high",
+        "feature/new-cli",
+        "add",
+        "guided",
+        "prompts",
+    ]
+
+
+def test_resolve_interactive_args_prompts_only_missing_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("pid.interactive.click.prompt", lambda *_, **__: "build thing")
+    monkeypatch.setattr("pid.interactive.click.confirm", lambda *_, **__: True)
+
+    assert resolve_interactive_args(["feature/x"], PIDConfig()) == [
+        "feature/x",
+        "build",
+        "thing",
+    ]
+
+
+def test_resolve_interactive_args_preserves_help_and_complete_args() -> None:
+    assert resolve_interactive_args(["--help"], PIDConfig()) == ["--help"]
+    assert resolve_interactive_args(["session", "--help"], PIDConfig()) == [
+        "session",
+        "--help",
+    ]
+    assert resolve_interactive_args(
+        ["2", "high", "feature/x", "build", "thing"], PIDConfig()
+    ) == ["2", "high", "feature/x", "build", "thing"]
+
+
+def test_resolve_interactive_args_prompts_branch_after_thinking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    answers = iter(["feature/x", "build thing"])
+    monkeypatch.setattr("pid.interactive.click.prompt", lambda *_, **__: next(answers))
+    monkeypatch.setattr("pid.interactive.click.confirm", lambda *_, **__: True)
+
+    assert resolve_interactive_args(["high"], PIDConfig()) == [
+        "high",
+        "feature/x",
+        "build",
+        "thing",
+    ]
+
+
+def test_resolve_interactive_args_reprompts_invalid_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    answers = iter(["0", "2", "bad", "medium", "", "feature/x", "build"])
+    monkeypatch.setattr("pid.interactive.click.prompt", lambda *_, **__: next(answers))
+    monkeypatch.setattr("pid.interactive.click.confirm", lambda *_, **__: True)
+
+    assert resolve_interactive_args([], PIDConfig()) == [
+        "2",
+        "medium",
+        "feature/x",
+        "build",
+    ]
+
+
+def test_resolve_interactive_args_abort_on_rejected_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("pid.interactive.click.prompt", lambda *_, **__: "feature/x")
+    monkeypatch.setattr("pid.interactive.click.confirm", lambda *_, **__: False)
+
+    with pytest.raises(click.Abort):
+        resolve_interactive_args(["high"], PIDConfig())
+
+
+def test_resolve_interactive_args_preserves_invalid_supplied_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_prompt(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("invalid supplied attempts should not prompt")
+
+    monkeypatch.setattr("pid.interactive.click.prompt", fail_prompt)
+
+    assert resolve_interactive_args(["0"], PIDConfig()) == ["0"]
+
+
+def test_main_resolves_interactive_args_when_stdin_is_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeContext:
+        args = ["prompt"]
+
+    class FakeStdin:
+        def isatty(self) -> bool:
+            return True
+
+    loaded_config = PIDConfig()
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_resolve(argv: list[str], config: PIDConfig) -> list[str]:
+        assert config is loaded_config
+        calls.append(("resolve", argv))
+        return ["resolved-branch", "resolved prompt"]
+
+    def fake_run_pid(argv: list[str], *, config: PIDConfig) -> int:
+        assert config is loaded_config
+        calls.append(("run", argv))
+        return 7
+
+    monkeypatch.setattr(cli_module.sys, "stdin", FakeStdin())
+    monkeypatch.setattr(cli_module, "load_config", lambda _path: loaded_config)
+    monkeypatch.setattr(cli_module, "resolve_interactive_args", fake_resolve)
+    monkeypatch.setattr(cli_module, "run_pid", fake_run_pid)
+
+    with pytest.raises(click.exceptions.Exit) as exc_info:
+        cli_module.main(cast(Any, FakeContext()), args=["feature/x"], config=None)
+
+    assert exc_info.value.exit_code == 7
+    assert calls == [
+        ("resolve", ["feature/x", "prompt"]),
+        ("run", ["resolved-branch", "resolved prompt"]),
+    ]
 
 
 def test_parse_args_session_help(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
- Add TTY-only interactive argument resolution so `pid` can guide users through missing attempts, thinking level, branch, and prompt values without blocking non-interactive use.
- Reuse supplied arguments when present, prompt only for ergonomic gaps, show current values before each prompt, and confirm final values before continuing.
- Document the new interactive CLI behavior and defaults in README usage examples.
- Add unit coverage for prompt flows, validation retries, help passthrough, confirmation aborts, and CLI integration.