### PR TITLE
feat: add CLI inspection commands and interactive prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ mise run test
 pid
 pid [ATTEMPTS] [THINKING] BRANCH PROMPT...
 pid session [ATTEMPTS] [THINKING] BRANCH [PROMPT...]
+pid sessions [--all|-a]
+pid config show|default|path
+pid --version
 ```
 
 Arguments:
@@ -90,6 +93,11 @@ pid 2 high fix/repair-ci "fix failing tests"
 pid docs/update-install update installation instructions
 pid session feature/explore-api
 pid session high feature/prototype-auth "explore auth UX options"
+pid sessions
+pid config show
+pid config default
+pid config path
+pid --version
 ```
 
 ### Interactive argument prompts
@@ -110,6 +118,17 @@ workflow:
 
 If stdin is not a TTY, pid keeps non-interactive behavior: missing required
 arguments print usage or validation errors instead of blocking for input.
+
+Inspection commands and options:
+
+| Command/option | Description |
+| --- | --- |
+| `pid sessions` | List active pid sessions from pid session logs, including current stage and log path. |
+| `pid sessions --all` / `-a` | List active, stale, and completed pid session logs. |
+| `pid config show` / `--print-config` | Print the loaded config as TOML. Honors `--config PATH`. |
+| `pid config default` / `--print-default-config` | Print built-in default config as TOML. |
+| `pid config path` | Print default/effective config path and session log directory. |
+| `pid version` / `--version` / `-v` | Print the installed pid version. |
 
 ## How it works
 
@@ -348,10 +367,11 @@ pr_merged_at_args = []
 
 Agent and forge CLI flags change over time; treat examples as starting points.
 
-Environment variables override the matching workflow config at runtime:
+Environment variables override the matching paths or workflow config at runtime:
 
 | Variable | Config default | Description |
 | --- | --- | --- |
+| `PID_LOG_DIR` | platform state/log directory | Directory where pid writes session logs and where `pid sessions` reads them. |
 | `PID_CHECKS_TIMEOUT_SECONDS` | `workflow.checks_timeout_seconds` | How long to wait for pending checks. |
 | `PID_CHECKS_POLL_INTERVAL_SECONDS` | `workflow.checks_poll_interval_seconds` | Delay between check polling attempts. |
 | `PID_MERGE_RETRY_LIMIT` | `workflow.merge_retry_limit` | Safety cap for moved-base merge/rebase retries that do not consume `ATTEMPTS`. |

--- a/src/pid/cli.py
+++ b/src/pid/cli.py
@@ -8,9 +8,12 @@ from typing import Annotated
 
 import typer
 
-from pid.config import load_config
+from pid import __version__
+from pid.config import PIDConfig, load_config
+from pid.diagnostics import active_sessions_table, config_to_toml, print_config_metadata
 from pid.errors import PIDAbort
 from pid.interactive import resolve_interactive_args
+from pid.output import echo_err, echo_out
 from pid.workflow import run_pid
 
 APP_CONTEXT = {
@@ -18,6 +21,10 @@ APP_CONTEXT = {
     "help_option_names": ["-h", "--help"],
     "ignore_unknown_options": True,
 }
+
+CONFIG_USAGE = "usage: pid config show|default|path"
+SESSIONS_USAGE = "usage: pid sessions [--all|-a]"
+VERSION_USAGE = "usage: pid version"
 
 app = typer.Typer(add_completion=False, context_settings=APP_CONTEXT)
 
@@ -45,11 +52,60 @@ def main(
             resolve_path=True,
         ),
     ] = None,
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            "-v",
+            help="Show pid version and exit.",
+        ),
+    ] = False,
+    print_current_config: Annotated[
+        bool,
+        typer.Option(
+            "--print-config",
+            help="Print loaded config as TOML and exit.",
+        ),
+    ] = False,
+    print_default_config: Annotated[
+        bool,
+        typer.Option(
+            "--print-default-config",
+            help="Print built-in default config as TOML and exit.",
+        ),
+    ] = False,
 ) -> None:
-    """Run pid."""
+    """Run pid.
+
+    Info commands:
+
+    - pid sessions [--all|-a]
+    - pid config show|default|path
+    - pid version
+    """
     raw_args = [*(args or []), *ctx.args]
+    if version or raw_args == ["version"]:
+        echo_out(f"pid {__version__}")
+        raise typer.Exit(0)
+
+    command_exit = _run_info_command(raw_args, config_path=config)
+    if command_exit is not None:
+        raise typer.Exit(command_exit)
+
+    if print_default_config:
+        typer.echo(config_to_toml(PIDConfig()), nl=False)
+        raise typer.Exit(0)
+
     try:
         loaded_config = load_config(config)
+    except PIDAbort as error:
+        raise typer.Exit(error.code) from error
+
+    if print_current_config:
+        typer.echo(config_to_toml(loaded_config), nl=False)
+        raise typer.Exit(0)
+
+    try:
         resolved_args = (
             resolve_interactive_args(raw_args, loaded_config)
             if sys.stdin.isatty()
@@ -57,4 +113,51 @@ def main(
         )
     except PIDAbort as error:
         raise typer.Exit(error.code) from error
+
     raise typer.Exit(run_pid(resolved_args, config=loaded_config))
+
+
+def _run_info_command(raw_args: list[str], *, config_path: Path | None) -> int | None:
+    if not raw_args:
+        return None
+
+    if raw_args in (["config", "path"], ["config-path"]):
+        typer.echo(print_config_metadata(config_path=config_path), nl=False)
+        return 0
+    if raw_args in (["config", "default"], ["default-config"]):
+        typer.echo(config_to_toml(PIDConfig()), nl=False)
+        return 0
+    if raw_args in (["config", "show"], ["config", "current"]):
+        try:
+            loaded_config = load_config(config_path)
+        except PIDAbort as error:
+            return error.code
+        typer.echo(config_to_toml(loaded_config), nl=False)
+        return 0
+    if raw_args[0] == "config":
+        echo_err(f"pid: unknown config command: {' '.join(raw_args[1:]) or '(none)'}")
+        echo_err(CONFIG_USAGE)
+        return 2
+
+    if raw_args in (["sessions"], ["sessions", "list"]):
+        typer.echo(active_sessions_table(), nl=False)
+        return 0
+    if raw_args in (
+        ["sessions", "--all"],
+        ["sessions", "-a"],
+        ["sessions", "list", "--all"],
+        ["sessions", "list", "-a"],
+    ):
+        typer.echo(active_sessions_table(include_all=True), nl=False)
+        return 0
+    if raw_args[0] == "sessions":
+        echo_err(f"pid: unknown sessions command: {' '.join(raw_args[1:]) or '(none)'}")
+        echo_err(SESSIONS_USAGE)
+        return 2
+
+    if raw_args[0] == "version":
+        echo_err(f"pid: unknown version command: {' '.join(raw_args[1:]) or '(none)'}")
+        echo_err(VERSION_USAGE)
+        return 2
+
+    return None

--- a/src/pid/diagnostics.py
+++ b/src/pid/diagnostics.py
@@ -1,0 +1,161 @@
+"""Diagnostic and inspection commands for pid."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import re
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+from typing import Any
+
+from pid.config import PIDConfig, default_config_path
+from pid.session_logging import session_log_dir
+
+_SESSION_PID_RE = re.compile(r"^pid: (?P<pid>\d+)$", re.MULTILINE)
+_SESSION_STARTED_RE = re.compile(r"^started: (?P<started>.+)$", re.MULTILINE)
+_SESSION_CWD_RE = re.compile(r"^cwd: (?P<cwd>.+)$", re.MULTILINE)
+_SESSION_ARGV_RE = re.compile(r"^argv: (?P<argv>.+)$", re.MULTILINE)
+_STEP_START_RE = re.compile(r"^STEP START: (?P<step>.+)$", re.MULTILINE)
+_STEP_END_RE = re.compile(
+    r"^STEP (?:PASS|FAIL status=\d+|END): (?P<step>.+)$", re.MULTILINE
+)
+
+
+def config_to_toml(config: PIDConfig) -> str:
+    """Render pid config as TOML."""
+
+    lines: list[str] = []
+    for section in fields(config):
+        value = getattr(config, section.name)
+        lines.append(f"[{section.name}]")
+        for item in fields(value):
+            item_value = getattr(value, item.name)
+            lines.append(f"{item.name} = {_toml_value(item_value)}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def print_config_metadata(*, config_path: Path | None = None) -> str:
+    """Return common pid path metadata."""
+
+    return (
+        f"config_path = {_toml_value(str(config_path or default_config_path()))}\n"
+        f"log_dir = {_toml_value(str(session_log_dir()))}\n"
+    )
+
+
+def active_sessions_table(*, include_all: bool = False) -> str:
+    """Return a human-readable table of pid sessions from session logs."""
+
+    sessions = list_sessions(include_all=include_all)
+    if not sessions:
+        return "no active pid sessions\n" if not include_all else "no pid sessions\n"
+
+    headers = ["pid", "state", "stage", "started", "cwd", "log"]
+    rows = [[session[key] for key in headers] for session in sessions]
+    widths = [
+        max(len(header), *(len(row[index]) for row in rows))
+        for index, header in enumerate(headers)
+    ]
+    lines = [
+        "  ".join(header.ljust(widths[index]) for index, header in enumerate(headers))
+    ]
+    lines.append("  ".join("-" * width for width in widths))
+    for row in rows:
+        lines.append(
+            "  ".join(value.ljust(widths[index]) for index, value in enumerate(row))
+        )
+    return "\n".join(lines) + "\n"
+
+
+def list_sessions(*, include_all: bool = False) -> list[dict[str, str]]:
+    """List active pid sessions, optionally including completed/stale logs."""
+
+    directory = session_log_dir()
+    if not directory.exists():
+        return []
+
+    sessions: list[dict[str, str]] = []
+    for path in sorted(directory.glob("pid-session-*.log"), reverse=True):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        session = _session_from_log(path, text)
+        if include_all or session["state"] == "active":
+            sessions.append(session)
+    return sessions
+
+
+def _session_from_log(path: Path, text: str) -> dict[str, str]:
+    pid = _match(_SESSION_PID_RE, text, "pid") or "?"
+    ended = "SESSION END" in text
+    live = pid.isdigit() and _pid_is_live(int(pid))
+    if ended:
+        state = "complete"
+    elif live:
+        state = "active"
+    else:
+        state = "stale"
+
+    return {
+        "pid": pid,
+        "state": state,
+        "stage": _current_stage(text, ended=ended),
+        "started": _match(_SESSION_STARTED_RE, text, "started") or "?",
+        "cwd": _match(_SESSION_CWD_RE, text, "cwd") or "?",
+        "argv": _match(_SESSION_ARGV_RE, text, "argv") or "?",
+        "log": str(path),
+    }
+
+
+def _current_stage(text: str, *, ended: bool) -> str:
+    if ended:
+        return "ended"
+    open_step: str | None = None
+    events: list[tuple[int, str, str]] = []
+    events.extend(
+        (match.start(), "start", match.group("step"))
+        for match in _STEP_START_RE.finditer(text)
+    )
+    events.extend(
+        (match.start(), "end", match.group("step"))
+        for match in _STEP_END_RE.finditer(text)
+    )
+    for _position, kind, step in sorted(events):
+        if kind == "start":
+            open_step = step
+        elif open_step == step:
+            open_step = None
+    return open_step or "running"
+
+
+def _match(pattern: re.Pattern[str], text: str, group: str) -> str | None:
+    match = pattern.search(text)
+    return match.group(group) if match else None
+
+
+def _pid_is_live(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _toml_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, tuple | list):
+        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    if is_dataclass(value) and not isinstance(value, type):
+        return _toml_value(dataclasses.asdict(value))
+    raise TypeError(f"unsupported TOML value: {value!r}")

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,9 +1,11 @@
+import os
 from pathlib import Path
 
 from click.utils import strip_ansi
 from typer.testing import CliRunner
 
 from pid.cli import app
+from pid.diagnostics import _pid_is_live, _toml_value
 
 runner = CliRunner()
 
@@ -26,6 +28,8 @@ def test_app_shows_typer_help() -> None:
     assert "Run pid." in output
     assert "[session] [ATTEMPTS] [THINKING] BRANCH" in output
     assert "--config" in output
+    assert "pid sessions [--all|-a]" in output
+    assert "pid config show|default|path" in output
     assert "Show this message and exit" in output
 
 
@@ -37,3 +41,163 @@ def test_invalid_config_returns_usage_error(tmp_path: Path) -> None:
 
     assert result.exit_code == 2
     assert "agent.default_thinking must be a string" in result.stderr
+
+
+def test_version_option_prints_version() -> None:
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.output.startswith("pid ")
+
+
+def test_version_command_prints_version() -> None:
+    result = runner.invoke(app, ["version"])
+
+    assert result.exit_code == 0
+    assert result.output.startswith("pid ")
+
+
+def test_version_command_rejects_extra_args() -> None:
+    result = runner.invoke(app, ["version", "extra"])
+
+    assert result.exit_code == 2
+    assert "usage: pid version" in result.stderr
+
+
+def test_default_config_command_prints_toml() -> None:
+    result = runner.invoke(app, ["config", "default"])
+
+    assert result.exit_code == 0
+    assert "[agent]" in result.output
+    assert 'command = ["pi"]' in result.output
+    assert "[workflow]" in result.output
+
+
+def test_bare_config_command_returns_usage_error() -> None:
+    result = runner.invoke(app, ["config"])
+
+    assert result.exit_code == 2
+    assert "usage: pid config show|default|path" in result.stderr
+
+
+def test_current_config_option_prints_loaded_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('[agent]\nlabel = "bot"\n')
+
+    result = runner.invoke(app, ["--config", str(config_path), "--print-config"])
+
+    assert result.exit_code == 0
+    assert 'label = "bot"' in result.output
+
+
+def test_current_config_command_prints_loaded_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('[agent]\nlabel = "bot"\n')
+
+    result = runner.invoke(app, ["--config", str(config_path), "config", "show"])
+
+    assert result.exit_code == 0
+    assert 'label = "bot"' in result.output
+
+
+def test_current_config_command_reports_invalid_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("[agent]\ndefault_thinking = 1\n")
+
+    result = runner.invoke(app, ["--config", str(config_path), "config", "show"])
+
+    assert result.exit_code == 2
+    assert "agent.default_thinking must be a string" in result.stderr
+
+
+def test_config_path_command_prints_paths(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+
+    result = runner.invoke(app, ["--config", str(config_path), "config", "path"])
+
+    assert result.exit_code == 0
+    assert f'config_path = "{config_path}"' in result.output
+    assert "log_dir = " in result.output
+
+
+def test_print_default_config_option_prints_toml() -> None:
+    result = runner.invoke(app, ["--print-default-config"])
+
+    assert result.exit_code == 0
+    assert "[agent]" in result.output
+
+
+def test_sessions_lists_active_logs(tmp_path: Path) -> None:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    log_path = log_dir / "pid-session-test.log"
+    log_path.write_text(
+        "=" * 88
+        + "\nSESSION START\n"
+        + "=" * 88
+        + f"\nstarted: 2026-04-27T00:00:00.000Z\npid: {os.getpid()}\n"
+        + "cwd: /repo\nargv: pid session feature/x\n"
+        + "STEP START: agent interactive session\n"
+    )
+
+    result = runner.invoke(app, ["sessions"], env={"PID_LOG_DIR": str(log_dir)})
+
+    assert result.exit_code == 0
+    assert "active" in result.output
+    assert "agent interactive session" in result.output
+    assert str(log_path) in result.output
+
+
+def test_sessions_without_logs_reports_none(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app, ["sessions"], env={"PID_LOG_DIR": str(tmp_path / "none")}
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "no active pid sessions\n"
+
+
+def test_unknown_sessions_command_returns_usage_error() -> None:
+    result = runner.invoke(app, ["sessions", "--bogus"])
+
+    assert result.exit_code == 2
+    assert "usage: pid sessions [--all|-a]" in result.stderr
+
+
+def test_sessions_all_includes_complete_and_stale_logs(tmp_path: Path) -> None:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "pid-session-complete.log").write_text(
+        "started: now\npid: 999999\ncwd: /done\nargv: pid done\nSESSION END\n"
+    )
+    (log_dir / "pid-session-stale.log").write_text(
+        "started: before\npid: 999999\ncwd: /stale\nargv: pid stale\n"
+        "STEP START: review\nSTEP END: review\n"
+    )
+
+    result = runner.invoke(
+        app, ["sessions", "--all"], env={"PID_LOG_DIR": str(log_dir)}
+    )
+    short_result = runner.invoke(
+        app, ["sessions", "-a"], env={"PID_LOG_DIR": str(log_dir)}
+    )
+
+    assert result.exit_code == 0
+    assert short_result.exit_code == 0
+    assert "complete" in result.output
+    assert "ended" in result.output
+    assert "stale" in result.output
+    assert "running" in result.output
+    assert short_result.output == result.output
+
+
+def test_diagnostics_helpers_cover_edge_cases() -> None:
+    assert _pid_is_live(999999) is False
+    assert _toml_value(True) == "true"
+    assert _toml_value(3) == "3"
+    try:
+        _toml_value(object())
+    except TypeError as error:
+        assert "unsupported TOML value" in str(error)
+    else:  # pragma: no cover
+        raise AssertionError("expected TypeError")


### PR DESCRIPTION
- Add standard CLI inspection paths: `--version`/`-v`, `pid version`, config show/default/path commands, and print-config options.
- Add `pid sessions` listing from session logs with active/stale/complete state, current stage, cwd, and log path, plus `--all`/`-a`.
- Add TTY-only interactive prompts for missing workflow arguments while preserving non-interactive validation behavior.
- Document new commands, `PID_LOG_DIR`, and interactive usage; expand tests for diagnostics, prompts, and CLI error handling.