### PR TITLE
feat: add init, prompt, and inspection CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,16 @@ Inspection commands and options:
 pid loads TOML config from the platform default path, or from `--config PATH`.
 The default path is optional; an explicit `--config PATH` must exist.
 
+Create a default config file with recommended defaults:
+
+```sh
+pid init
+```
+
+The command writes to the platform default path and prints that path. It accepts
+no arguments, does not accept `--config`, and refuses to overwrite an existing
+config file.
+
 Default config paths:
 
 | Platform/env | Path |

--- a/src/pid/cli.py
+++ b/src/pid/cli.py
@@ -9,7 +9,7 @@ from typing import Annotated
 import typer
 
 from pid import __version__
-from pid.config import PIDConfig, load_config
+from pid.config import PIDConfig, init_config, load_config
 from pid.diagnostics import active_sessions_table, config_to_toml, print_config_metadata
 from pid.errors import PIDAbort
 from pid.interactive import resolve_interactive_args
@@ -75,7 +75,7 @@ def main(
         ),
     ] = False,
 ) -> None:
-    """Run pid.
+    """Run pid. Use `pid init` to create the default config.
 
     Info commands:
 
@@ -97,6 +97,18 @@ def main(
         raise typer.Exit(0)
 
     try:
+        if raw_args and raw_args[0] == "init":
+            if config is not None:
+                echo_err(
+                    "pid: init does not accept --config; "
+                    "it always writes the default config path"
+                )
+                raise typer.Exit(2)
+            if len(raw_args) > 1:
+                echo_err("pid: init does not accept arguments")
+                raise typer.Exit(2)
+            init_config()
+            raise typer.Exit(0)
         loaded_config = load_config(config)
     except PIDAbort as error:
         raise typer.Exit(error.code) from error

--- a/src/pid/config.py
+++ b/src/pid/config.py
@@ -12,12 +12,91 @@ from pathlib import Path
 from typing import Any
 
 from pid.errors import abort
-from pid.output import echo_err
+from pid.output import echo_err, echo_out
 
 DEFAULT_THINKING_LEVELS = ("low", "medium", "high", "xhigh")
 AGENT_TEMPLATE_FIELDS = ("prompt", "thinking")
 COMMIT_TEMPLATE_FIELDS = ("title",)
 FORGE_TEMPLATE_FIELDS = ("branch", "title", "body", "pr_url", "head_oid")
+
+DEFAULT_CONFIG_TOML = """[agent]
+command = ["pi"]
+non_interactive_args = ["--thinking", "{thinking}", "-p", "{prompt}"]
+interactive_args = ["--thinking", "{thinking}"]
+default_thinking = "medium"
+review_thinking = "high"
+thinking_levels = ["low", "medium", "high", "xhigh"]
+label = "agent"
+
+[runtime]
+keep_screen_awake = false
+
+[commit]
+verifier_command = ["cog"]
+verifier_args = ["verify", "{title}"]
+automated_feedback_title = "fix: address automated feedback"
+rebase_feedback_title = "fix: resolve latest base changes"
+
+[forge]
+command = ["gh"]
+label = "github"
+default_branch_args = [
+  "repo",
+  "view",
+  "--json",
+  "defaultBranchRef",
+  "--jq",
+  ".defaultBranchRef.name",
+]
+pr_view_args = ["pr", "view", "{branch}"]
+pr_create_args = ["pr", "create", "--title", "{title}", "--body", "{body}"]
+pr_edit_args = ["pr", "edit", "{branch}", "--title", "{title}", "--body", "{body}"]
+pr_url_args = ["pr", "view", "{branch}", "--json", "url", "--jq", ".url"]
+pr_head_oid_args = [
+  "pr",
+  "view",
+  "{branch}",
+  "--json",
+  "headRefOid",
+  "--jq",
+  ".headRefOid",
+]
+pr_checks_args = ["pr", "checks", "{branch}"]
+pr_merge_args = [
+  "pr",
+  "merge",
+  "{branch}",
+  "--squash",
+  "--match-head-commit",
+  "{head_oid}",
+  "--subject",
+  "{title}",
+  "--body",
+  "{body}",
+]
+pr_merged_at_args = [
+  "pr",
+  "view",
+  "{pr_url}",
+  "--json",
+  "mergedAt",
+  "--jq",
+  '.mergedAt // ""',
+]
+checks_pending_exit_codes = [8]
+no_checks_markers = ["no checks"]
+
+[prompts]
+diagnostic_output_limit = 20000
+# message, review, ci_fix, and rebase_fix use long built-in templates.
+# Override any one with a TOML string or multiline string.
+
+[workflow]
+checks_timeout_seconds = 1800
+checks_poll_interval_seconds = 10
+merge_retry_limit = 20
+trust_mise = true
+"""
 
 MESSAGE_PROMPT_FIELDS = ("original_prompt", "branch", "base_rev", "output_path")
 REVIEW_PROMPT_FIELDS = ("original_prompt", "review_target")
@@ -307,6 +386,29 @@ def default_config_path() -> Path:
         return home / "Library" / "Application Support" / "pid" / "config.toml"
 
     return home / ".config" / "pid" / "config.toml"
+
+
+def init_config() -> Path:
+    """Write recommended defaults to the default config path."""
+
+    config_path = default_config_path()
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        echo_err(f"pid: could not write config at {config_path}: {error}")
+        abort(2)
+
+    try:
+        with config_path.open("x", encoding="utf-8") as config_file:
+            config_file.write(DEFAULT_CONFIG_TOML)
+    except FileExistsError:
+        echo_err(f"pid: config file already exists: {config_path}")
+        abort(2)
+    except OSError as error:
+        echo_err(f"pid: could not write config at {config_path}: {error}")
+        abort(2)
+    echo_out(f"pid: wrote config to {config_path}")
+    return config_path
 
 
 def load_config(path: Path | None = None) -> PIDConfig:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 import pid.config as config_module
-from pid.config import default_config_path, load_config, parse_config
+from pid.config import default_config_path, init_config, load_config, parse_config
 from pid.errors import PIDAbort
 from pid.models import CommitMessage
 
@@ -55,6 +55,34 @@ def test_default_missing_config_path_uses_defaults(
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "missing-config-home"))
 
     assert load_config() == config_module.PIDConfig()
+
+
+def test_init_config_writes_recommended_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config-home"))
+
+    config_path = init_config()
+
+    assert config_path == tmp_path / "config-home" / "pid" / "config.toml"
+    assert load_config() == config_module.PIDConfig()
+    assert "wrote config to" in capsys.readouterr().out
+
+
+def test_init_config_refuses_to_overwrite_existing_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config-home"))
+    config_path = default_config_path()
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("[runtime]\nkeep_screen_awake = true\n")
+
+    with pytest.raises(PIDAbort) as exc_info:
+        init_config()
+
+    assert exc_info.value.code == 2
+    assert config_path.read_text() == "[runtime]\nkeep_screen_awake = true\n"
+    assert "config file already exists" in capsys.readouterr().err
 
 
 def test_runtime_keep_screen_awake_defaults_off(tmp_path: Path) -> None:

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+import pytest
 from click.utils import strip_ansi
 from typer.testing import CliRunner
 
@@ -25,12 +26,49 @@ def test_app_shows_typer_help() -> None:
     output = strip_ansi(result.output)
 
     assert result.exit_code == 0
-    assert "Run pid." in output
+    assert "Run pid. Use `pid init` to create the default config." in output
     assert "[session] [ATTEMPTS] [THINKING] BRANCH" in output
     assert "--config" in output
     assert "pid sessions [--all|-a]" in output
     assert "pid config show|default|path" in output
     assert "Show this message and exit" in output
+
+
+def test_init_command_writes_default_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    result = runner.invoke(app, ["init"])
+
+    config_path = tmp_path / "xdg" / "pid" / "config.toml"
+    assert result.exit_code == 0
+    assert f"pid: wrote config to {config_path}" in result.output
+    assert config_path.exists()
+
+
+def test_init_command_rejects_arguments(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    result = runner.invoke(app, ["init", "extra"])
+
+    assert result.exit_code == 2
+    assert "pid: init does not accept arguments" in result.stderr
+    assert not (tmp_path / "xdg" / "pid" / "config.toml").exists()
+
+
+def test_init_command_rejects_explicit_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    result = runner.invoke(app, ["--config", str(tmp_path / "custom.toml"), "init"])
+
+    assert result.exit_code == 2
+    assert "pid: init does not accept --config" in result.stderr
+    assert not (tmp_path / "xdg" / "pid" / "config.toml").exists()
 
 
 def test_invalid_config_returns_usage_error(tmp_path: Path) -> None:


### PR DESCRIPTION
- Add `pid init` to write recommended defaults to the platform config path, print where it was created, and reject overwrites, extra args, or `--config`.
- Add default-config TOML output, config path/show/default commands, version handling, and session-log inspection helpers for easier troubleshooting.
- Add TTY-only prompts for missing workflow arguments while preserving non-interactive validation behavior.
- Update README usage/configuration docs and expand tests for init, config inspection, session diagnostics, and prompt resolution.