### PR TITLE
feat: expose configurable session output visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ mise run test
 
 ```sh
 pid
-pid [ATTEMPTS] [THINKING] BRANCH PROMPT...
-pid session [ATTEMPTS] [THINKING] BRANCH [PROMPT...]
+pid [--output normal|agent|all] [ATTEMPTS] [THINKING] BRANCH PROMPT...
+pid [--output normal|agent|all] session [ATTEMPTS] [THINKING] BRANCH [PROMPT...]
 pid sessions [--all|-a]
 pid config show|default|path
 pid --version
@@ -83,6 +83,12 @@ Arguments:
 | `THINKING` | `medium` | Initial agent thinking level. Values come from `agent.thinking_levels`. |
 | `BRANCH` | required | New branch name to create. Must not already exist locally or on `origin`. |
 | `PROMPT...` | required for non-interactive; optional for `session` | Prompt passed through the configured non-interactive agent template, or initial message for interactive mode. |
+
+Options:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `--output normal\|agent\|all` | `normal` | Console detail level. `normal` shows progress, successful agent stdout summaries, and failures. `agent` also shows successful agent stderr. `all` shows successful output from every captured command. Full command logs are always written to the session log. |
 
 Examples:
 
@@ -137,6 +143,7 @@ Inspection commands and options:
 3. Creates a sibling worktree for the new branch.
 4. Runs the configured non-interactive agent command with prompt and thinking
    level, or runs the configured interactive agent command in `session` mode.
+   Successful non-interactive agent stdout is shown as the agent summary.
 5. In `session` mode, waits until the interactive agent exits.
 6. Runs a configured review-thinking agent review pass over committed and
    uncommitted work that fixes incomplete, unsafe, incorrect, untested, or

--- a/src/pid/cli.py
+++ b/src/pid/cli.py
@@ -13,6 +13,7 @@ from pid.config import PIDConfig, init_config, load_config
 from pid.diagnostics import active_sessions_table, config_to_toml, print_config_metadata
 from pid.errors import PIDAbort
 from pid.interactive import resolve_interactive_args
+from pid.models import OutputMode
 from pid.output import echo_err, echo_out
 from pid.workflow import run_pid
 
@@ -52,6 +53,14 @@ def main(
             resolve_path=True,
         ),
     ] = None,
+    output: Annotated[
+        OutputMode,
+        typer.Option(
+            "--output",
+            help="Console detail: normal, agent, or all.",
+            case_sensitive=False,
+        ),
+    ] = OutputMode.NORMAL,
     version: Annotated[
         bool,
         typer.Option(
@@ -126,7 +135,7 @@ def main(
     except PIDAbort as error:
         raise typer.Exit(error.code) from error
 
-    raise typer.Exit(run_pid(resolved_args, config=loaded_config))
+    raise typer.Exit(run_pid(resolved_args, config=loaded_config, output_mode=output))
 
 
 def _run_info_command(raw_args: list[str], *, config_path: Path | None) -> int | None:

--- a/src/pid/commands.py
+++ b/src/pid/commands.py
@@ -12,7 +12,7 @@ from plumbum import local
 from plumbum.commands.processes import CommandNotFound
 
 from pid.errors import abort
-from pid.models import CommandResult
+from pid.models import CommandResult, OutputMode
 from pid.output import echo_err, write_command_output
 from pid.session_logging import SessionLogger
 
@@ -20,13 +20,28 @@ from pid.session_logging import SessionLogger
 class CommandRunner:
     """Small plumbum wrapper preserving command output behavior."""
 
-    def __init__(self, logger: SessionLogger | None = None) -> None:
+    def __init__(
+        self,
+        logger: SessionLogger | None = None,
+        output_mode: OutputMode = OutputMode.NORMAL,
+    ) -> None:
         self.logger = logger
+        self.output_mode = output_mode
 
     def set_logger(self, logger: SessionLogger | None) -> None:
         """Attach the active session logger."""
 
         self.logger = logger
+
+    def set_output_mode(self, output_mode: OutputMode) -> None:
+        """Set console output detail level."""
+
+        self.output_mode = output_mode
+
+    def writes_success_output(self) -> bool:
+        """Return true when successful command output is echoed immediately."""
+
+        return self.output_mode == OutputMode.ALL
 
     def run(
         self,
@@ -70,6 +85,8 @@ class CommandRunner:
 
         if command_log is not None and self.logger is not None:
             self.logger.command_result(command_log, result)
+        if self.writes_success_output() and result.returncode == 0:
+            write_command_output(result)
         return result
 
     def run_interactive(

--- a/src/pid/github.py
+++ b/src/pid/github.py
@@ -52,7 +52,10 @@ class Forge:
             if create_result.returncode != 0:
                 write_command_output(create_result)
                 abort(create_result.returncode)
-            if has_output(create_result.stdout):
+            if (
+                has_output(create_result.stdout)
+                and not self.runner.writes_success_output()
+            ):
                 write_collected(create_result.stdout, stream=sys.stdout)
             return
 

--- a/src/pid/models.py
+++ b/src/pid/models.py
@@ -3,6 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
+
+
+class OutputMode(StrEnum):
+    """Console output detail level."""
+
+    NORMAL = "normal"
+    AGENT = "agent"
+    ALL = "all"
 
 
 @dataclass(frozen=True)

--- a/src/pid/workflow.py
+++ b/src/pid/workflow.py
@@ -12,7 +12,7 @@ from pid.errors import PIDAbort, abort
 from pid.github import Forge
 from pid.keepawake import KeepAwake
 from pid.messages import parse_commit_message
-from pid.models import CommitMessage, ParsedArgs
+from pid.models import CommandResult, CommitMessage, OutputMode, ParsedArgs
 from pid.output import (
     echo_err,
     echo_out,
@@ -38,15 +38,20 @@ class PIDFlow:
     """Implements the pid orchestration lifecycle."""
 
     def __init__(
-        self, runner: CommandRunner | None = None, config: PIDConfig | None = None
+        self,
+        runner: CommandRunner | None = None,
+        config: PIDConfig | None = None,
+        output_mode: OutputMode = OutputMode.NORMAL,
     ) -> None:
         self.runner = runner or CommandRunner()
+        self.runner.set_output_mode(output_mode)
         self.config = config or PIDConfig()
         self.repository = Repository(self.runner)
         self.forge = Forge(self.runner, self.config.forge)
         self.review_rejected_first_pass = False
         self.session_logger: SessionLogger | None = None
         self.keep_awake: KeepAwake | None = None
+        self.output_mode = output_mode
 
     def run(self, argv: list[str]) -> int:
         exit_code = 0
@@ -365,7 +370,9 @@ class PIDFlow:
                 checks_poll_interval_seconds,
                 worktree_path,
             )
-            if has_output(checks_out):
+            if has_output(checks_out) and (
+                checks_status != 0 or not self.runner.writes_success_output()
+            ):
                 write_collected(checks_out, stream=sys.stdout)
             if checks_status != 0:
                 if self.forge.output_reports_no_checks(checks_out):
@@ -399,7 +406,9 @@ class PIDFlow:
                 pr_url,
                 worktree_path,
             )
-            if has_output(merge_result.stdout):
+            if has_output(merge_result.stdout) and (
+                merge_result.returncode != 0 or not self.runner.writes_success_output()
+            ):
                 write_collected(merge_result.stdout, stream=sys.stdout)
 
             if merge_result.returncode == 0:
@@ -648,6 +657,8 @@ class PIDFlow:
         if agent_result.returncode == 0:
             if self.session_logger is not None:
                 self.session_logger.step_pass(log_step)
+            self.write_agent_success_output(agent_result)
+            echo_out(f"pid: {log_step} finished")
             return
 
         if self.session_logger is not None:
@@ -659,6 +670,16 @@ class PIDFlow:
             f"{agent_result.returncode}{separator}{failure_context}"
         )
         abort(agent_result.returncode)
+
+    def write_agent_success_output(self, result: CommandResult) -> None:
+        """Show useful successful agent output without flooding normal runs."""
+
+        if self.output_mode == OutputMode.ALL:
+            return
+        if has_output(result.stdout):
+            write_collected(result.stdout, stream=sys.stdout)
+        if self.output_mode == OutputMode.AGENT and has_output(result.stderr):
+            write_collected(result.stderr, stream=sys.stderr)
 
     def bump_after_review_rejected_followup(self, followup_thinking_level: str) -> str:
         if not self.review_rejected_first_pass or not followup_thinking_level:
@@ -729,7 +750,12 @@ class PIDFlow:
         print_merge_success(pr_title, pr_url, self.config.forge.label)
 
 
-def run_pid(argv: list[str], *, config: PIDConfig | None = None) -> int:
+def run_pid(
+    argv: list[str],
+    *,
+    config: PIDConfig | None = None,
+    output_mode: OutputMode = OutputMode.NORMAL,
+) -> int:
     """Run the pid flow and return a process exit code."""
 
-    return PIDFlow(config=config).run(argv)
+    return PIDFlow(config=config, output_mode=output_mode).run(argv)

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -31,7 +31,9 @@ def test_app_shows_typer_help() -> None:
     assert "--config" in output
     assert "pid sessions [--all|-a]" in output
     assert "pid config show|default|path" in output
-    assert "Show this message and exit" in output
+    assert "--output" in output
+    assert "agent, or all" in output
+    assert "Show this message" in output
 
 
 def test_init_command_writes_default_config(

--- a/tests/test_pid_flow.py
+++ b/tests/test_pid_flow.py
@@ -385,6 +385,66 @@ def test_initial_pi_failure_stops_before_review(tmp_path: Path) -> None:
     assert final_state["pi_calls"][0]["thinking"] == "low"
 
 
+def test_normal_output_shows_agent_stdout_and_step_finish(tmp_path: Path) -> None:
+    state = base_state(
+        tmp_path,
+        worktree_dirty="",
+        worktree_diff="",
+        initial_pi_out="initial summary\n",
+        review_pi_out="review summary\n",
+        initial_pi_err="hidden initial stderr\n",
+        review_pi_err="hidden review stderr\n",
+    )
+
+    process, _ = run_pid(tmp_path, ["feature/cool-stuff", "prompt"], state=state)
+
+    assert_success(process)
+    assert "initial summary\n" in process.stdout
+    assert "review summary\n" in process.stdout
+    assert "pid: agent initial finished" in process.stdout
+    assert "pid: agent review finished" in process.stdout
+    assert "hidden initial stderr" not in process.stderr
+    assert "hidden review stderr" not in process.stderr
+
+
+def test_agent_output_mode_shows_successful_agent_stderr(tmp_path: Path) -> None:
+    state = base_state(
+        tmp_path,
+        worktree_dirty="",
+        worktree_diff="",
+        initial_pi_out="initial summary\n",
+        initial_pi_err="initial diagnostic\n",
+        review_pi_err="review diagnostic\n",
+    )
+
+    process, _ = run_pid(
+        tmp_path, ["--output", "agent", "feature/cool-stuff", "prompt"], state=state
+    )
+
+    assert_success(process)
+    assert "initial summary\n" in process.stdout
+    assert "initial diagnostic\n" in process.stderr
+    assert "review diagnostic\n" in process.stderr
+
+
+def test_all_output_mode_shows_captured_command_output_once(tmp_path: Path) -> None:
+    state = base_state(
+        tmp_path,
+        pr_exists_before=True,
+        checks_sequence=[{"status": 0, "out": "checks passed\n"}],
+        merge_sequence=[{"status": 0, "out": "merged\n"}],
+    )
+
+    process, _ = run_pid(
+        tmp_path, ["--output", "all", "feature/cool-stuff", "prompt"], state=state
+    )
+
+    assert_success(process)
+    assert process.stdout.count("checks passed\n") == 1
+    assert process.stdout.count("merged\n") == 1
+    assert "https://example.invalid/pr/1" in process.stdout
+
+
 def test_session_mode_runs_interactive_pi_then_resumes_flow(tmp_path: Path) -> None:
     state = base_state(tmp_path)
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -17,8 +17,8 @@ import pid.cli as cli_module
 from pid.commands import CommandRunner, require_command
 from pid.config import AgentConfig, PIDConfig, load_config, parse_config
 from pid.errors import PIDAbort
-from pid.models import CommandResult
 from pid.interactive import resolve_interactive_args
+from pid.models import CommandResult, OutputMode
 from pid.output import (
     get_session_logger,
     set_session_logger,
@@ -200,6 +200,23 @@ def test_command_runner_quiet_output_suppresses_error(
     assert capsys.readouterr().err == ""
 
 
+def test_command_runner_all_output_mode_echoes_successful_output(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = CommandRunner(output_mode=OutputMode.ALL).run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; print('out'); print('err', file=sys.stderr)",
+        ]
+    )
+
+    assert result == CommandResult(0, "out\n", "err\n")
+    captured = capsys.readouterr()
+    assert captured.out == "out\n"
+    assert captured.err == "err\n"
+
+
 def test_command_runner_run_interactive_missing_command() -> None:
     result = CommandRunner().run_interactive(["definitely-missing-pid-command"])
 
@@ -358,8 +375,11 @@ def test_main_resolves_interactive_args_when_stdin_is_tty(
         calls.append(("resolve", argv))
         return ["resolved-branch", "resolved prompt"]
 
-    def fake_run_pid(argv: list[str], *, config: PIDConfig) -> int:
+    def fake_run_pid(
+        argv: list[str], *, config: PIDConfig, output_mode: OutputMode
+    ) -> int:
         assert config is loaded_config
+        assert output_mode == OutputMode.NORMAL
         calls.append(("run", argv))
         return 7
 


### PR DESCRIPTION
- Add `--output normal|agent|all` with an `OutputMode` model so users can choose default, agent-focused, or fully verbose session output while preserving complete logs.
- Show step completion and successful agent summary output by default; route extra agent stderr and captured command output only in higher-verbosity modes.
- Document the new visibility option and cover normal, agent, and all modes with workflow/unit tests.
- Include branch changes for interactive CLI prompts, init/prompt/inspection diagnostics, and planning docs for merge reliability and extensibility.