### PR TITLE
test: run pytest suite in parallel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Use `mise` tasks rather than invoking tools directly:
 | --- | --- |
 | `mise run lint` | Run hk-managed checks. |
 | `mise run fix` | Run hk-managed formatters and fixers. |
-| `mise run test` | Run pytest with coverage reporting and a 95% coverage gate. |
+| `mise run test` | Run pytest in parallel with coverage reporting and a 95% coverage gate. |
 | `mise run build` | Build the Python package. |
 | `mise run check` | Run all project checks. |
 | `mise run release:bump` | Bump the package version. |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ uv tool install .
 ```
 
 For development, use `mise` from the repository root. `mise run test` runs
-pytest with the repository coverage gate:
+pytest in parallel with the repository coverage gate:
 
 ```sh
 mise trust
@@ -417,8 +417,8 @@ Environment variables override the matching paths or workflow config at runtime:
 
 ## Development
 
-This repository uses `mise` for tools and tasks. The test task runs pytest with
-coverage reporting and fails below 95% total coverage.
+This repository uses `mise` for tools and tasks. The test task runs pytest in
+parallel with coverage reporting and fails below 95% total coverage.
 
 ```sh
 mise trust

--- a/mise.toml
+++ b/mise.toml
@@ -42,7 +42,7 @@ run = "hk check --all"
 [tasks.test]
 description = "Run test suite with coverage gate"
 depends = ["install"]
-run = "uv run pytest --cov=pid --cov-report=term-missing --cov-fail-under=95"
+run = "uv run pytest -n auto --cov=pid --cov-report=term-missing --cov-fail-under=95"
 
 [tasks.build]
 description = "Build project package"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
   "hypothesis>=6.152.3",
   "pytest>=9.0.3",
   "pytest-cov>=7.0.0",
+  "pytest-xdist>=3.8.0",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -72,6 +72,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "hypothesis"
 version = "6.152.3"
 source = { registry = "https://pypi.org/simple" }
@@ -137,6 +146,7 @@ dev = [
     { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -151,6 +161,7 @@ dev = [
     { name = "hypothesis", specifier = ">=6.152.3" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
 ]
 
 [[package]]
@@ -211,6 +222,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add `pytest-xdist` as a dev dependency and lock its `execnet` dependency.
- Update `mise run test` to use `pytest -n auto` while keeping coverage reporting and the 95% gate.
- Refresh README and CONTRIBUTING test docs to describe parallel execution.
- Run `mise run check` before release publishing so releases keep passing the full check task.