### PR TITLE
feat: improve CLI output structure and visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Options:
 | --- | --- | --- |
 | `--output normal\|agent\|all` | `normal` | Console detail level. `normal` shows progress, successful agent stdout summaries, and failures. `agent` also shows successful agent stderr. `all` shows successful output from every captured command. Full command logs are always written to the session log. |
 
+During a run, pid prints a Rich summary panel for branch, attempts, thinking
+level, flow, agent, forge, and output mode. Long-running sections are separated
+with phase dividers such as Prepare, Agent, Review, Message + commit, and each
+PR attempt.
+
 Examples:
 
 ```sh

--- a/src/pid/output.py
+++ b/src/pid/output.py
@@ -9,10 +9,11 @@ from pid.session_logging import SessionLogger
 
 from rich.console import Console
 from rich.panel import Panel
+from rich.rule import Rule
 from rich.table import Table
 from rich.text import Text
 
-from pid.models import CommandResult, CommitMessage
+from pid.models import CommandResult, CommitMessage, OutputMode, ParsedArgs
 
 OUT_CONSOLE = Console(highlight=False)
 _CURRENT_LOGGER: SessionLogger | None = None
@@ -63,6 +64,61 @@ def echo_err(message: str) -> None:
     if _CURRENT_LOGGER is not None:
         _CURRENT_LOGGER.output("stderr", message)
     print(message, file=sys.stderr)
+
+
+def print_run_summary(
+    parsed: ParsedArgs,
+    *,
+    agent_label: str,
+    forge_label: str,
+    output_mode: OutputMode,
+) -> None:
+    """Print a compact run summary before the workflow starts."""
+
+    if _CURRENT_LOGGER is not None:
+        _CURRENT_LOGGER.event(
+            "run summary: "
+            f"branch={parsed.branch} attempts={parsed.max_attempts} "
+            f"thinking={parsed.thinking_level} mode={output_mode.value}"
+        )
+    flow = "interactive session" if parsed.interactive else "non-interactive agent"
+    table = Table.grid(padding=(0, 1))
+    table.add_column(style="bold")
+    table.add_column()
+    table.add_row("branch", parsed.branch)
+    table.add_row("attempts", str(parsed.max_attempts))
+    table.add_row("thinking", parsed.thinking_level)
+    table.add_row("flow", flow)
+    table.add_row("agent", agent_label)
+    table.add_row("forge", forge_label)
+    table.add_row("output", output_mode.value)
+    OUT_CONSOLE.print(
+        Panel.fit(
+            table,
+            title=Text("pid run", style="bold magenta"),
+            border_style="magenta",
+        )
+    )
+
+
+def print_phase(title: str, detail: str = "") -> None:
+    """Print a visual phase divider for long-running workflow sections."""
+
+    event = f"phase: {title}"
+    if detail:
+        event = f"{event} - {detail}"
+    if _CURRENT_LOGGER is not None:
+        _CURRENT_LOGGER.event(event)
+    label = Text(f" {title} ", style="bold cyan")
+    if detail:
+        label.append(f" {detail}", style="dim")
+    OUT_CONSOLE.print(Rule(label, style="cyan"))
+
+
+def print_attempt_header(attempt: int, max_attempts: int) -> None:
+    """Print a visual PR attempt divider."""
+
+    print_phase(f"PR attempt {attempt}/{max_attempts}")
 
 
 def print_commit_message(message: CommitMessage) -> None:

--- a/src/pid/workflow.py
+++ b/src/pid/workflow.py
@@ -17,8 +17,11 @@ from pid.models import CommandResult, CommitMessage, OutputMode, ParsedArgs
 from pid.output import (
     echo_err,
     echo_out,
+    print_attempt_header,
     print_commit_message,
     print_merge_success,
+    print_phase,
+    print_run_summary,
     set_session_logger,
     write_collected,
     write_command_output,
@@ -87,8 +90,15 @@ class PIDFlow:
         self.start_session_logging(argv)
         self.start_keep_awake()
         self.log_parsed_args(parsed)
+        print_run_summary(
+            parsed,
+            agent_label=self.config.agent.label,
+            forge_label=self.config.forge.label,
+            output_mode=self.output_mode,
+        )
         followup_thinking_level = parsed.thinking_level
 
+        print_phase("Prepare", "validate repo, branch, tools")
         validate_branch_name(self.runner, parsed.branch)
 
         repo_root = self.resolve_repo_root()
@@ -125,6 +135,7 @@ class PIDFlow:
         if self.config.workflow.trust_mise and shutil.which("mise") is not None:
             self.runner.require(["mise", "trust", "."], cwd=worktree_path)
 
+        print_phase("Agent", "create initial changes")
         if parsed.interactive:
             self.run_agent_session(
                 parsed.interactive_prompt,
@@ -149,6 +160,7 @@ class PIDFlow:
         review_target = review_target_for(
             base_rev, initial_commit_count, has_output(initial_dirty)
         )
+        print_phase("Review", review_target.replace("_", " "))
         review_prompt = build_review_prompt(
             original_prompt=parsed.prompt,
             review_target=review_target,
@@ -181,6 +193,7 @@ class PIDFlow:
             echo_out("pid: no changes or commits after agent; stopping before PR")
             abort(0)
 
+        print_phase("Message + commit", "generate metadata and create commit")
         commit_message = self.generate_commit_message(
             parsed=parsed,
             base_rev=base_rev,
@@ -329,6 +342,7 @@ class PIDFlow:
                 self.session_logger.separator(
                     f"PR ATTEMPT {attempt}/{parsed.max_attempts}"
                 )
+            print_attempt_header(attempt, parsed.max_attempts)
             echo_out(f"pid: PR attempt {attempt}/{parsed.max_attempts}")
             commit_title = self.repository.commit_dirty_automated_feedback(
                 worktree_path,

--- a/tests/test_pid_flow.py
+++ b/tests/test_pid_flow.py
@@ -407,6 +407,37 @@ def test_normal_output_shows_agent_stdout_and_step_finish(tmp_path: Path) -> Non
     assert "hidden review stderr" not in process.stderr
 
 
+def test_structured_output_shows_run_summary_and_phase_headers(
+    tmp_path: Path,
+) -> None:
+    state = base_state(tmp_path)
+
+    process, _ = run_pid(
+        tmp_path,
+        ["2", "high", "feature/cool-stuff", "build", "thing"],
+        state=state,
+    )
+
+    assert_success(process)
+    assert "pid run" in process.stdout
+    assert "branch" in process.stdout
+    assert "feature/cool-stuff" in process.stdout
+    assert "attempts 2" in process.stdout
+    assert "thinking high" in process.stdout
+    assert "non-interactive agent" in process.stdout
+    assert "forge    github" in process.stdout
+    assert "output   normal" in process.stdout
+    assert "Prepare" in process.stdout
+    assert "validate repo, branch, tools" in process.stdout
+    assert "Agent" in process.stdout
+    assert "create initial changes" in process.stdout
+    assert "Review" in process.stdout
+    assert "uncommitted changes" in process.stdout
+    assert "Message + commit" in process.stdout
+    assert "generate metadata and create commit" in process.stdout
+    assert "PR attempt 1/2" in process.stdout
+
+
 def test_agent_output_mode_shows_successful_agent_stderr(tmp_path: Path) -> None:
     state = base_state(
         tmp_path,

--- a/tests/test_session_logging.py
+++ b/tests/test_session_logging.py
@@ -74,6 +74,15 @@ def test_session_log_captures_agent_steps_commands_and_outputs(tmp_path: Path) -
     assert len(logs) == 1
     log = logs[0].read_text()
     assert "SESSION START" in log
+    assert (
+        "run summary: branch=feature/cool-stuff attempts=3 thinking=medium "
+        "mode=normal" in log
+    )
+    assert "phase: Prepare - validate repo, branch, tools" in log
+    assert "phase: Agent - create initial changes" in log
+    assert "phase: Review - Review the uncommitted changes in this worktree." in log
+    assert "phase: Message + commit - generate metadata and create commit" in log
+    assert "phase: PR attempt 1/3" in log
     assert "STEP START: agent initial" in log
     assert "COMMAND STDOUT" in log
     assert "agent did work" in log


### PR DESCRIPTION
- Add a Rich run summary panel showing branch, attempts, thinking level, flow, agent, forge, and output mode before work starts.
- Add visual phase dividers for prepare, agent, review, message/commit, and PR attempts so long runs are easier to follow.
- Record the new summary and phase events in session logs, with tests covering console output and logging behavior.
- Document the improved run output and update the test workflow to run pytest in parallel with pytest-xdist.