### PR TITLE
fix: update interactive prompts in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ workflow:
   prompt.
 - `pid session` prompts for branch only because the initial session prompt is
   optional.
-- pid shows current values before each prompt and asks for final confirmation
-  before continuing.
+- pid shows current values before each prompt, updates that summary in place
+  on TTY output, and asks for final confirmation before continuing.
 
 If stdin is not a TTY, pid keeps non-interactive behavior: missing required
 arguments print usage or validation errors instead of blocking for input.

--- a/src/pid/interactive.py
+++ b/src/pid/interactive.py
@@ -19,6 +19,7 @@ def resolve_interactive_args(argv: list[str], config: PIDConfig) -> list[str]:
     args = list(argv)
     resolved: list[str] = []
     prompted = False
+    display = _InteractiveDisplay()
     prompt_all_defaults = not args
     interactive = False
 
@@ -36,7 +37,9 @@ def resolve_interactive_args(argv: list[str], config: PIDConfig) -> list[str]:
         resolved.append(attempts)
     elif prompt_all_defaults:
         attempts = _prompt_attempts(
-            attempts, _values(attempts, config.agent.default_thinking, "", "")
+            attempts,
+            _values(attempts, config.agent.default_thinking, "", ""),
+            display=display,
         )
         resolved.append(attempts)
         prompted = True
@@ -50,6 +53,7 @@ def resolve_interactive_args(argv: list[str], config: PIDConfig) -> list[str]:
             thinking,
             config.agent.thinking_levels,
             _values(attempts, thinking, "", ""),
+            display=display,
         )
         resolved.append(thinking)
         prompted = True
@@ -63,6 +67,7 @@ def resolve_interactive_args(argv: list[str], config: PIDConfig) -> list[str]:
             "Branch",
             example="feature/short-description",
             values=_values(attempts, thinking, branch, ""),
+            display=display,
         )
         resolved.append(branch)
         prompted = True
@@ -75,12 +80,13 @@ def resolve_interactive_args(argv: list[str], config: PIDConfig) -> list[str]:
             "Prompt",
             example="Add OAuth login and tests",
             values=_values(attempts, thinking, branch, prompt),
+            display=display,
         )
         resolved.extend(prompt.split())
         prompted = True
 
     if prompted:
-        _show_values(_values(attempts, thinking, branch, prompt))
+        display.render(_values(attempts, thinking, branch, prompt))
         if not click.confirm("Continue with these values?", default=True):
             raise click.Abort()
 
@@ -96,44 +102,85 @@ def _values(attempts: str, thinking: str, branch: str, prompt: str) -> dict[str,
     }
 
 
-def _show_values(values: dict[str, str]) -> None:
-    click.echo("\npid values:")
-    for key, value in values.items():
-        click.echo(f"  {key}: {value}")
-    click.echo("")
+class _InteractiveDisplay:
+    """Render prompt summary in-place when stdout is interactive."""
+
+    def __init__(self) -> None:
+        self._line_count = 0
+        self._can_update = click.get_text_stream("stdout").isatty()
+
+    def render(self, values: dict[str, str], *, error: str | None = None) -> None:
+        self._clear_previous()
+        lines = _value_lines(values)
+        if error and self._can_update:
+            lines.append(error)
+        click.echo("\n".join(lines))
+        if error and not self._can_update:
+            click.echo(error, err=True)
+        self._line_count = (
+            len(lines) + 1
+        )  # include next click.prompt/click.confirm line
+
+    def _clear_previous(self) -> None:
+        if not self._can_update or self._line_count <= 0:
+            return
+        click.echo(f"\033[{self._line_count}A", nl=False, color=True)
+        for index in range(self._line_count):
+            click.echo("\033[2K\r", nl=False, color=True)
+            if index < self._line_count - 1:
+                click.echo("\033[1B", nl=False, color=True)
+        click.echo(f"\033[{self._line_count - 1}A", nl=False, color=True)
 
 
-def _prompt_attempts(default: str, values: dict[str, str]) -> str:
+def _value_lines(values: dict[str, str]) -> list[str]:
+    lines = ["pid values:"]
+    lines.extend(f"  {key}: {value}" for key, value in values.items())
+    lines.append("")
+    return lines
+
+
+def _prompt_attempts(
+    default: str, values: dict[str, str], *, display: _InteractiveDisplay
+) -> str:
+    error: str | None = None
     while True:
-        _show_values(values)
+        display.render(values, error=error)
         value = click.prompt(
             "Attempts (positive integer)", default=default, show_default=True
         )
         if re.fullmatch(r"[1-9][0-9]*", value):
             return value
-        click.echo("Enter a positive integer, e.g. 3.", err=True)
+        error = "Enter a positive integer, e.g. 3."
 
 
 def _prompt_thinking(
-    default: str, thinking_levels: tuple[str, ...], values: dict[str, str]
+    default: str,
+    thinking_levels: tuple[str, ...],
+    values: dict[str, str],
+    *,
+    display: _InteractiveDisplay,
 ) -> str:
     levels = ", ".join(thinking_levels)
+    error: str | None = None
     while True:
-        _show_values(values)
+        display.render(values, error=error)
         value = click.prompt(
             f"Thinking level ({levels})", default=default, show_default=True
         )
         if value in thinking_levels:
             return value
-        click.echo(f"Choose one of: {levels}.", err=True)
+        error = f"Choose one of: {levels}."
 
 
-def _prompt_required(label: str, *, example: str, values: dict[str, str]) -> str:
+def _prompt_required(
+    label: str, *, example: str, values: dict[str, str], display: _InteractiveDisplay
+) -> str:
+    error: str | None = None
     while True:
-        _show_values(values)
+        display.render(values, error=error)
         value = click.prompt(
             f"{label} (example: {example})", default="", show_default=False
         )
         if value.strip():
             return value.strip()
-        click.echo(f"{label} is required. Example: {example}", err=True)
+        error = f"{label} is required. Example: {example}"

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -14,6 +14,7 @@ import pytest
 import pid
 import pid.config as config_module
 import pid.cli as cli_module
+import pid.interactive as interactive_module
 from pid.commands import CommandRunner, require_command
 from pid.config import AgentConfig, PIDConfig, load_config, parse_config
 from pid.errors import PIDAbort
@@ -263,6 +264,55 @@ def test_output_helpers_preserve_newline_behavior(
     assert captured.out == "no newline\n"
     assert stdout.getvalue() == "out\n"
     assert stderr.getvalue() == "err\n"
+
+
+class TTYStream:
+    def isatty(self) -> bool:
+        return True
+
+
+def test_interactive_display_clears_previous_tty_render(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "pid.interactive.click.get_text_stream", lambda _name: TTYStream()
+    )
+    display = interactive_module._InteractiveDisplay()
+    values = {
+        "attempts": "3",
+        "thinking": "medium",
+        "branch": "(unset)",
+        "prompt": "(unset)",
+    }
+
+    display.render(values)
+    display.render({**values, "branch": "feature/x"})
+
+    output = capsys.readouterr().out
+    assert "\033[7A" in output
+    assert "\033[2K\r" in output
+
+
+def test_interactive_display_clears_validation_error_tty_render(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "pid.interactive.click.get_text_stream", lambda _name: TTYStream()
+    )
+    display = interactive_module._InteractiveDisplay()
+    values = {
+        "attempts": "3",
+        "thinking": "medium",
+        "branch": "(unset)",
+        "prompt": "(unset)",
+    }
+
+    display.render(values, error="Enter a positive integer, e.g. 3.")
+    capsys.readouterr()
+    display.render(values)
+
+    output = capsys.readouterr().out
+    assert output.startswith("\033[8A")
 
 
 def test_resolve_interactive_args_prompts_all_values_when_empty(


### PR DESCRIPTION
- Replace repeated interactive value summary prints with a shared display that clears prior TTY renders.
- Reuse the display for attempts, thinking, branch, prompt, validation errors, and final confirmation while preserving non-TTY behavior.
- Add run summary panels, phase dividers, PR attempt headers, and matching session log events for clearer workflow progress.
- Cover prompt clearing and structured output with tests, and enable parallel pytest with docs and lockfile updates.