### PR TITLE
fix: handle agent-pushed session branches

### DIFF
--- a/src/pid/repository.py
+++ b/src/pid/repository.py
@@ -258,10 +258,33 @@ class Repository:
     def contains_ref(self, worktree_path: str, ref: str) -> bool:
         """Return true when HEAD contains ref."""
 
+        return self.is_ancestor(worktree_path, ref, "HEAD")
+
+    def is_ancestor(self, worktree_path: str, ancestor: str, descendant: str) -> bool:
+        """Return true when ancestor is reachable from descendant."""
+
         result = self.runner.run(
-            ["git", "merge-base", "--is-ancestor", ref, "HEAD"], cwd=worktree_path
+            ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+            cwd=worktree_path,
         )
         return result.returncode == 0
+
+    def remote_branch_oid(self, worktree_path: str, branch: str) -> str:
+        """Return origin branch object ID, or empty string when branch is absent."""
+
+        result = self.runner.run(
+            ["git", "ls-remote", "--heads", "origin", branch], cwd=worktree_path
+        )
+        if result.returncode != 0:
+            write_command_output(result)
+            abort(result.returncode)
+
+        branch_ref = f"refs/heads/{branch}"
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and parts[1] == branch_ref:
+                return parts[0]
+        return ""
 
     def rebase_in_progress(self, worktree_path: str) -> bool:
         """Return true when git reports a rebase state directory."""

--- a/src/pid/workflow.py
+++ b/src/pid/workflow.py
@@ -201,7 +201,14 @@ class PIDFlow:
         )
         self.verify_commit_title(commit_message)
 
+        pre_commit_head = self.repository.output(
+            ["rev-parse", "HEAD"], cwd=worktree_path
+        ).strip()
         self.repository.commit_initial_changes(base_rev, worktree_path, commit_message)
+        post_commit_head = self.repository.output(
+            ["rev-parse", "HEAD"], cwd=worktree_path
+        ).strip()
+        rewritten_head = pre_commit_head if pre_commit_head != post_commit_head else ""
         commit_title = self.repository.output(
             ["log", "-1", "--format=%s"], cwd=worktree_path
         ).strip()
@@ -211,6 +218,7 @@ class PIDFlow:
             base_rev=base_rev,
             commit_message=commit_message,
             commit_title=commit_title,
+            rewritten_head=rewritten_head,
             followup_thinking_level=followup_thinking_level,
             main_worktree=main_worktree,
             default_branch=default_branch,
@@ -314,6 +322,7 @@ class PIDFlow:
         base_rev: str,
         commit_message: CommitMessage,
         commit_title: str,
+        rewritten_head: str,
         followup_thinking_level: str,
         main_worktree: str,
         default_branch: str,
@@ -417,23 +426,13 @@ class PIDFlow:
                 self.verify_commit_title(commit_message)
                 message_state_hash = self.repository.state_hash(worktree_path)
 
-            if need_force_push:
-                self.runner.require(
-                    [
-                        "git",
-                        "push",
-                        "--force-with-lease",
-                        "-u",
-                        "origin",
-                        parsed.branch,
-                    ],
-                    cwd=worktree_path,
-                )
-                need_force_push = False
-            else:
-                self.runner.require(
-                    ["git", "push", "-u", "origin", parsed.branch], cwd=worktree_path
-                )
+            self.push_pr_branch(
+                branch=parsed.branch,
+                worktree_path=worktree_path,
+                force=need_force_push,
+                rewritten_head=rewritten_head,
+            )
+            need_force_push = False
 
             self.forge.ensure_pr(parsed.branch, commit_message, worktree_path)
             pr_title = commit_message.title
@@ -607,6 +606,60 @@ class PIDFlow:
 
         echo_err(
             f"pid: exhausted {parsed.max_attempts} attempts; leaving worktree: {worktree_path}"
+        )
+        abort(1)
+
+    def push_pr_branch(
+        self, *, branch: str, worktree_path: str, force: bool, rewritten_head: str
+    ) -> None:
+        """Push a PR branch, safely tolerating agent-pushed rewritten history."""
+
+        if force:
+            self.runner.require(
+                ["git", "push", "--force-with-lease", "-u", "origin", branch],
+                cwd=worktree_path,
+            )
+            return
+
+        remote_oid = self.repository.remote_branch_oid(worktree_path, branch)
+        if not remote_oid:
+            self.runner.require(
+                ["git", "push", "-u", "origin", branch], cwd=worktree_path
+            )
+            return
+
+        local_head = self.repository.output(
+            ["rev-parse", "HEAD"], cwd=worktree_path
+        ).strip()
+        if self.repository.is_ancestor(worktree_path, remote_oid, local_head):
+            self.runner.require(
+                ["git", "push", "-u", "origin", branch], cwd=worktree_path
+            )
+            return
+
+        if rewritten_head and self.repository.is_ancestor(
+            worktree_path, remote_oid, rewritten_head
+        ):
+            echo_out(
+                "pid: remote branch contains agent-pushed rewritten history; "
+                "using force-with-lease"
+            )
+            self.runner.require(
+                [
+                    "git",
+                    "push",
+                    f"--force-with-lease=refs/heads/{branch}:{remote_oid}",
+                    "-u",
+                    "origin",
+                    branch,
+                ],
+                cwd=worktree_path,
+            )
+            return
+
+        echo_err(
+            "pid: remote branch changed unexpectedly; refusing to overwrite "
+            f"origin/{branch}"
         )
         abort(1)
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -188,10 +188,27 @@ def cmd_git(state, original_args):
         finish(state, 0, str(state.get("commit_count", 0)))
 
     if args[:2] == ["merge-base", "--is-ancestor"]:
+        ancestor = args[2]
+        descendant = args[3]
+        if ancestor == descendant:
+            finish(state, 0)
+        ancestor_map = state.get("ancestor_map", {})
+        key = f"{ancestor}..{descendant}"
+        if key in ancestor_map:
+            finish(state, 0 if ancestor_map[key] else 1)
         if state.get("base_is_ancestor_sequence"):
             item = state["base_is_ancestor_sequence"].pop(0)
             state["base_is_ancestor"] = bool(item)
         finish(state, 0 if state.get("base_is_ancestor", True) else 1)
+
+    if args[:3] == ["ls-remote", "--heads", "origin"]:
+        branch = args[3]
+        oid = state.get("remote_branch_oid", "")
+        if state.get("ls_remote_fail"):
+            finish(state, 1, err="ls-remote failed")
+        if oid:
+            finish(state, 0, f"{oid}\trefs/heads/{branch}")
+        finish(state)
 
     if args == ["diff", "--binary", "--no-ext-diff"]:
         finish(state, 0, state.get("worktree_diff", ""))
@@ -235,6 +252,10 @@ def cmd_git(state, original_args):
     if args and args[0] == "push":
         if state.get("push_fail"):
             finish(state, 1, err="push failed")
+        if "--delete" in args:
+            state["remote_branch_oid"] = ""
+        else:
+            state["remote_branch_oid"] = state.get("head", state["base_rev"])
         finish(state)
 
     if args and args[0] == "fetch":
@@ -422,6 +443,11 @@ def cmd_pi(state, args):
 
     if kind == "initial" and state.get("initial_pi_commit_count") is not None:
         state["commit_count"] = state["initial_pi_commit_count"]
+        state["head"] = state.get(
+            "initial_pi_head", f"agent-commit-{state['initial_pi_commit_count']}"
+        )
+    if kind == "initial" and state.get("initial_push_remote_oid"):
+        state["remote_branch_oid"] = state["initial_push_remote_oid"]
 
     if kind == "review":
         if state.get("review_changes"):

--- a/tests/test_pid_flow.py
+++ b/tests/test_pid_flow.py
@@ -498,6 +498,57 @@ def test_session_mode_runs_interactive_pi_then_resumes_flow(tmp_path: Path) -> N
     assert final_state["pi_calls"][1]["kind"] == "review"
 
 
+def test_session_mode_force_with_lease_pushes_agent_rewritten_branch(
+    tmp_path: Path,
+) -> None:
+    state = base_state(
+        tmp_path,
+        initial_pi_commit_count=1,
+        initial_pi_head="agent123",
+        initial_push_remote_oid="agent123",
+        ancestor_map={
+            "agent123..commit-1": False,
+        },
+    )
+
+    process, final_state = run_pid(
+        tmp_path, ["session", "feature/cool-stuff"], state=state
+    )
+
+    assert_success(process)
+    assert "agent-pushed rewritten history" in process.stdout
+    assert [
+        "push",
+        "--force-with-lease=refs/heads/feature/cool-stuff:agent123",
+        "-u",
+        "origin",
+        "feature/cool-stuff",
+    ] in [call["args"] for call in calls(final_state, "git", "push")]
+
+
+def test_session_mode_refuses_unrelated_remote_branch_after_agent(
+    tmp_path: Path,
+) -> None:
+    state = base_state(
+        tmp_path,
+        initial_pi_commit_count=1,
+        initial_pi_head="agent123",
+        initial_push_remote_oid="other456",
+        ancestor_map={
+            "other456..commit-1": False,
+            "other456..agent123": False,
+        },
+    )
+
+    process, final_state = run_pid(
+        tmp_path, ["session", "feature/cool-stuff"], state=state
+    )
+
+    assert process.returncode == 1
+    assert "remote branch changed unexpectedly" in process.stderr
+    assert not calls(final_state, "gh", "pr", "create")
+
+
 def test_session_mode_allows_no_initial_prompt(tmp_path: Path) -> None:
     state = base_state(tmp_path, pi_fail_kinds=["review"], pi_fail_status=17)
 


### PR DESCRIPTION
## Summary\n- Record pre-metadata HEAD before pid squashes/recommits agent work.\n- Check origin branch OID before PR push and use exact force-with-lease when it matches rewritten agent history.\n- Abort on unrelated remote branch changes instead of overwriting.\n- Add session flow tests for safe force-with-lease and unsafe remote refusal.\n\nRefs #32\n\n## Validation\n- mise run check