### PR TITLE
feat: render interactive prompts with Rich panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ workflow:
   prompt.
 - `pid session` prompts for branch only because the initial session prompt is
   optional.
-- pid shows current values before each prompt, updates that summary in place
-  on TTY output, and asks for final confirmation before continuing.
+- pid shows current values in a Rich summary panel before each prompt,
+  updates that panel in place on TTY output, displays validation errors inside
+  the panel, and asks for final confirmation before continuing.
 
 If stdin is not a TTY, pid keeps non-interactive behavior: missing required
 arguments print usage or validation errors instead of blocking for input.

--- a/src/pid/interactive.py
+++ b/src/pid/interactive.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import re
+import shutil
 
 import click
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
 
 from pid.config import PIDConfig
 
@@ -108,18 +113,31 @@ class _InteractiveDisplay:
     def __init__(self) -> None:
         self._line_count = 0
         self._can_update = click.get_text_stream("stdout").isatty()
+        terminal_width = shutil.get_terminal_size((88, 24)).columns
+        width = min(terminal_width, 88) if self._can_update else 88
+        self._console = Console(
+            color_system="auto" if self._can_update else None,
+            force_terminal=self._can_update,
+            highlight=False,
+            width=width,
+        )
 
     def render(self, values: dict[str, str], *, error: str | None = None) -> None:
         self._clear_previous()
-        lines = _value_lines(values)
-        if error and self._can_update:
-            lines.append(error)
-        click.echo("\n".join(lines))
+        rendered = self._render(values, error=error if self._can_update else None)
+        click.echo(rendered, nl=False, color=True)
         if error and not self._can_update:
             click.echo(error, err=True)
         self._line_count = (
-            len(lines) + 1
+            len(rendered.splitlines()) + 1
         )  # include next click.prompt/click.confirm line
+
+    def _render(self, values: dict[str, str], *, error: str | None) -> str:
+        with self._console.capture() as capture:
+            self._console.print(
+                _prompt_summary(values, error=error, width=self._console.width)
+            )
+        return capture.get()
 
     def _clear_previous(self) -> None:
         if not self._can_update or self._line_count <= 0:
@@ -132,11 +150,34 @@ class _InteractiveDisplay:
         click.echo(f"\033[{self._line_count - 1}A", nl=False, color=True)
 
 
-def _value_lines(values: dict[str, str]) -> list[str]:
-    lines = ["pid values:"]
-    lines.extend(f"  {key}: {value}" for key, value in values.items())
-    lines.append("")
-    return lines
+def _prompt_summary(
+    values: dict[str, str], *, error: str | None, width: int | None = None
+) -> Panel:
+    table = Table.grid(padding=(0, 2))
+    table.add_column(style="bold magenta", no_wrap=True)
+    table.add_column()
+    table.add_row("attempts", _summary_value(values["attempts"]))
+    table.add_row("thinking", _summary_value(values["thinking"]))
+    table.add_row("branch", _summary_value(values["branch"]))
+    table.add_row("prompt", _summary_value(values["prompt"]))
+
+    renderable = table
+    if error:
+        renderable = Group(table, Text(f"✗ {error}", style="bold red"))
+
+    return Panel(
+        renderable,
+        title=Text("pid prompt", style="bold magenta"),
+        subtitle=Text("enter to accept defaults", style="dim"),
+        border_style="magenta",
+        width=width,
+    )
+
+
+def _summary_value(value: str) -> Text:
+    if value == "(unset)" or value.startswith("(default"):
+        return Text(value, style="dim")
+    return Text(value)
 
 
 def _prompt_attempts(

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 import io
+import os
+import re
 import runpy
 import sys
 from pathlib import Path
@@ -269,6 +271,70 @@ def test_output_helpers_preserve_newline_behavior(
 class TTYStream:
     def isatty(self) -> bool:
         return True
+
+
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def test_interactive_display_renders_rich_panel_with_values() -> None:
+    display = interactive_module._InteractiveDisplay()
+    rendered = display._render(
+        {
+            "attempts": "3",
+            "thinking": "medium",
+            "branch": "feature/x",
+            "prompt": "build thing",
+        },
+        error=None,
+    )
+
+    assert "╭" in rendered
+    assert "pid prompt" in rendered
+    assert "enter to accept defaults" in rendered
+    assert "attempts" in rendered
+    assert "feature/x" in rendered
+
+
+def test_interactive_display_renders_validation_error() -> None:
+    display = interactive_module._InteractiveDisplay()
+    rendered = display._render(
+        {
+            "attempts": "3",
+            "thinking": "medium",
+            "branch": "(unset)",
+            "prompt": "(unset)",
+        },
+        error="Enter a positive integer, e.g. 3.",
+    )
+
+    assert "✗ Enter a positive integer, e.g. 3." in rendered
+
+
+def test_interactive_display_tty_width_matches_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "pid.interactive.click.get_text_stream", lambda _name: TTYStream()
+    )
+    monkeypatch.setattr(
+        "pid.interactive.shutil.get_terminal_size",
+        lambda _fallback: os.terminal_size((40, 24)),
+    )
+    display = interactive_module._InteractiveDisplay()
+
+    rendered = display._render(
+        {
+            "attempts": "3",
+            "thinking": "medium",
+            "branch": "feature/long-name-that-wraps",
+            "prompt": "build a nicer interactive prompt UI",
+        },
+        error=None,
+    )
+    plain = ANSI_ESCAPE_RE.sub("", rendered)
+
+    assert display._console.width == 40
+    assert max(len(line) for line in plain.splitlines()) <= 40
 
 
 def test_interactive_display_clears_previous_tty_render(


### PR DESCRIPTION
- Replace the plain interactive value summary with a Rich panel that highlights current prompt values and defaults.
- Keep TTY updates in place while rendering validation errors inside the panel and preserving stderr errors for non-TTY output.
- Size the panel to the active terminal width, capped at 88 columns, to avoid overflow on narrow terminals.
- Document the richer prompt behavior and add unit coverage for panel rendering, errors, and width handling.