### PR TITLE
feat: make pid workflows extensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Inspection commands and options:
 | `pid config show` / `--print-config` | Print the loaded config as TOML. Honors `--config PATH`. |
 | `pid config default` / `--print-default-config` | Print built-in default config as TOML. |
 | `pid config path` | Print default/effective config path and session log directory. |
+| `pid x extensions list` | List enabled extensions. |
+| `pid x <extension-command> [ARGS...]` | Run an enabled extension command. |
 | `pid version` / `--version` / `-v` | Print the installed pid version. |
 
 ## How it works
@@ -296,6 +298,10 @@ base_refresh_enabled = true
 base_refresh_stages = ["before_pr"]
 base_refresh_limit = 3
 base_refresh_agent_conflict_fix = true
+
+[extensions]
+enabled = []
+paths = []
 ```
 
 `agent.command`, `forge.command`, and `commit.verifier_command` may be arrays of
@@ -333,6 +339,10 @@ before it considers the run successful. If the forge queued the merge or enabled
 auto-merge, pid polls for up to `workflow.merge_confirmation_timeout_seconds`
 seconds before cleaning up. If confirmation times out, pid exits nonzero and
 leaves the PR/worktree for manual follow-up.
+
+Extensions can hook, add, replace, or disable workflow steps and can register
+commands under `pid x ...`. See [docs/EXTENSIONS.md](docs/EXTENSIONS.md) for the
+API, trust boundary, and runnable local-extension examples.
 
 Prompt templates must be non-blank and support these fields:
 

--- a/docs/EXTENSIBILITY_ROADMAP.md
+++ b/docs/EXTENSIBILITY_ROADMAP.md
@@ -1,9 +1,16 @@
 # Extensibility roadmap
 
+Status: validated against the current `src/pid` workflow on 2026-04-28.
+Initial API version 1 is implemented; see `docs/EXTENSIONS.md` for the current
+extension API. Continue to preserve the compatibility guardrails below: keep the
+legacy `pid [session] [ATTEMPTS] [THINKING] BRANCH [PROMPT...]` flow, preserve
+existing base-refresh and merge-confirmation behavior, and reserve new CLI
+command words deliberately.
+
 Goal: keep `pid` tiny, stable, and useful by default, while making most
 behavior replaceable without forking. Core should be a small orchestration
 kernel; user/project code should provide new commands, workflow steps,
-policies, prompts, forge adapters, and output behavior.
+policies, prompts, forge adapters, event sinks, and output behavior.
 
 ## Design principles
 
@@ -17,12 +24,14 @@ policies, prompts, forge adapters, and output behavior.
   access to hidden mutable state.
 - Safe defaults: missing/broken extensions fail with clear diagnostics before
   destructive steps.
+- Backward compatibility: zero-extension runs must keep the current CLI,
+  stdout/stderr expectations, exit codes, and cleanup behavior.
 
 ## Current shape
 
-`src/pid/workflow.py` currently owns the whole lifecycle in one
-`PIDFlow._run` method. This makes behavior easy to follow, but hard to override
-one piece of the workflow.
+`src/pid/workflow.py` owns the lifecycle through `PIDFlow._run`,
+`PIDFlow.run_pr_loop`, and helper methods. This keeps behavior easy to follow,
+but makes it hard to override one piece of the workflow.
 
 Already configurable:
 
@@ -30,14 +39,28 @@ Already configurable:
 - Forge command templates in `ForgeConfig`.
 - Commit verifier in `CommitConfig`.
 - Runtime and workflow tuning in `RuntimeConfig` / `WorkflowConfig`.
+- Output detail via `OutputMode`.
+
+Important current behavior to preserve:
+
+- Flexible positional CLI parsing, including `session` mode.
+- Strict config validation for existing core tables.
+- Main worktree cleanliness and branch/worktree guards before generated work.
+- Optional `mise trust` after worktree creation.
+- Review and message-generation passes before commit/PR creation.
+- PR loop with configurable check waits, CI fix attempts, base refresh stages,
+  merge retries, merge confirmation polling, and cleanup.
+- Session logs with current user-visible progress messages.
 
 Main friction:
 
 - No first-class extension loading.
 - No stable hook names.
 - No step registry.
-- No way to add CLI subcommands without editing `cli.py`.
 - No structured workflow events beyond session log strings.
+- No way to add extension commands without reserving a top-level CLI word or a
+  separate script.
+- Strict config parsing currently rejects a top-level `[extensions]` table.
 - `PIDFlow` directly constructs `Repository`, `Forge`, `SessionLogger`, and
   `KeepAwake`.
 
@@ -46,13 +69,14 @@ Main friction:
 ```text
 CLI
   -> config loader
-  -> extension loader
+  -> installed extension loader
   -> service container
   -> workflow engine
        -> ordered workflow steps
        -> before/after/error hooks
        -> policies
        -> events
+       -> project-local extension loader after repo resolution
 ```
 
 Core package remains small:
@@ -60,6 +84,7 @@ Core package remains small:
 - `pid.config`: load/validate config.
 - `pid.extensions`: discover/register extensions.
 - `pid.context`: typed runtime context and services.
+- `pid.events`: structured workflow events and sinks.
 - `pid.workflow`: generic step engine plus default workflow definition.
 - `pid.builtins`: default steps, policies, adapters.
 
@@ -72,6 +97,7 @@ from pid.extensions import Extension, ExtensionRegistry
 
 class MyExtension(Extension):
     name = "my-extension"
+    api_version = "1"
 
     def register(self, registry: ExtensionRegistry) -> None:
         registry.add_hook("before.run_initial_agent", my_hook)
@@ -79,20 +105,26 @@ class MyExtension(Extension):
         registry.add_cli_command("doctor", doctor_command)
 ```
 
-Load from Python entry points:
+Load installed packages from Python entry points:
 
 ```toml
 [project.entry-points."pid.extensions"]
 my_extension = "my_pkg.pid_ext:MyExtension"
 ```
 
-Also load local project extensions from config for quick hacks:
+Also load project-local extensions from config for quick project-specific
+behavior:
 
 ```toml
 [extensions]
 enabled = ["my_extension"]
 paths = [".pid/extensions"]
 ```
+
+Project-local paths are resolved relative to the repository root. They load
+after `parse_args` and `resolve_repo_root`, but before worktree creation or any
+destructive step. Installed entry-point extensions can load earlier because they
+do not need a repository path.
 
 ## Registry capabilities
 
@@ -106,34 +138,66 @@ Start minimal:
 - `replace_service(name, factory)`
 - `add_cli_command(name, callback)`
 
-Keep hook and step names stable once documented.
+Registry rules:
+
+- Built-ins register first; extensions modify that default registry.
+- Step names, hook names, and extension command names must be unique after
+  registration.
+- Ordering is deterministic: `(order, extension_name, registration_index)` for
+  hooks and explicit `before`/`after` constraints for steps.
+- Registration failures include the extension name and fail before destructive
+  steps.
+- Keep hook and step names stable once documented.
 
 ## Workflow steps
 
-Break `PIDFlow._run` into named steps. Initial built-in order:
+Break `PIDFlow._run` and `PIDFlow.run_pr_loop` into named steps. Initial
+built-in order should reflect the current workflow:
 
 1. `parse_args`
 2. `start_session_logging`
 3. `start_keep_awake`
-4. `validate_branch`
-5. `resolve_repo`
-6. `require_commands`
-7. `validate_clean_main_worktree`
-8. `update_default_branch`
-9. `create_worktree`
-10. `trust_mise`
-11. `run_initial_agent`
-12. `run_review_agent`
-13. `stop_if_no_changes`
-14. `generate_message`
-15. `verify_commit_title`
-16. `commit_changes`
-17. `create_or_update_pr`
-18. `wait_for_checks`
-19. `fix_failed_checks`
-20. `refresh_pr_message`
-21. `merge_pr`
-22. `cleanup`
+4. `render_run_summary`
+5. `validate_branch`
+6. `resolve_repo_root`
+7. `require_commands`
+8. `resolve_main_worktree`
+9. `validate_clean_main_worktree`
+10. `resolve_default_branch`
+11. `update_default_branch`
+12. `capture_base_rev`
+13. `create_worktree`
+14. `trust_mise`
+15. `run_initial_agent`
+16. `inspect_initial_changes`
+17. `run_review_agent`
+18. `inspect_review_changes`
+19. `stop_if_no_changes`
+20. `generate_message`
+21. `verify_commit_title`
+22. `commit_changes`
+23. `start_pr_attempt`
+24. `commit_automated_feedback`
+25. `refresh_base_before_message`
+26. `regenerate_message_if_needed`
+27. `refresh_base_before_pr`
+28. `push_pr_branch`
+29. `create_or_update_pr`
+30. `wait_for_checks`
+31. `fix_failed_checks`
+32. `refresh_base_after_checks`
+33. `repush_after_base_refresh`
+34. `refresh_pr_message`
+35. `merge_pr`
+36. `wait_for_merge_confirmation`
+37. `recover_failed_merge`
+38. `cleanup`
+39. `shutdown`
+
+PR-loop steps can repeat. `fix_failed_checks` consumes `ATTEMPTS` as it does
+today. `recover_failed_merge` uses `workflow.merge_retry_limit` as it does
+today. Base-refresh steps are conditional on `workflow.base_refresh_enabled`,
+`workflow.base_refresh_stages`, and `workflow.base_refresh_limit`.
 
 Each step should be a callable:
 
@@ -142,7 +206,8 @@ def step(ctx: WorkflowContext) -> StepResult:
     ...
 ```
 
-`StepResult` can be `continue`, `skip`, `stop(code)`, or `retry`.
+`StepResult` can be `continue`, `skip`, `stop(code)`, or `retry`. Retry must be
+bounded by a policy or an existing workflow limit.
 
 ## Hook model
 
@@ -170,11 +235,15 @@ Example use cases:
 - Replace review prompt based on file paths changed.
 - Add extra CI failure classifier.
 
+Hook failures should default to fail-fast. A later policy can allow explicitly
+non-blocking hooks, but blocking is safer for API version 1.
+
 ## Context and services
 
 Create `WorkflowContext` with typed, explicit state:
 
 - config
+- extension config
 - parsed args
 - repo root
 - main worktree
@@ -182,12 +251,24 @@ Create `WorkflowContext` with typed, explicit state:
 - branch
 - default branch
 - base rev
+- output mode
+- follow-up thinking level
+- review-rejected-first-pass flag
+- pre/post state hashes
 - commit message
+- commit title
+- rewritten head
 - PR URL
+- PR title/body
+- checks status/output
+- attempt counters
+- base-refresh counters
+- merge retry counters
 - runner
 - repository service
 - forge service
-- logger
+- keep-awake service
+- logger/session logger
 - event bus
 - scratch dict for extensions
 
@@ -195,6 +276,7 @@ Avoid arbitrary mutation where possible. Prefer helper methods:
 
 - `ctx.set_commit_message(...)`
 - `ctx.require_worktree()`
+- `ctx.mark_force_push_needed(...)`
 - `ctx.emit(event)`
 
 ## Override targets
@@ -207,16 +289,20 @@ High-value replaceable pieces:
 - Commit message generator: agent, conventional-commit parser, template,
   local model.
 - Checks policy: timeout, retry, required checks, ignored checks.
+- Base-refresh policy: stages, conflict handling, rebasing strategy.
 - Merge policy: squash/rebase/merge commit/manual stop.
+- Merge confirmation policy: poll, trust merge command, or manual approval.
 - Cleanup policy: always remove worktree vs keep on failure.
+- Event sinks: session log, JSONL, notifications.
 - Output renderer: Rich, JSON, quiet, machine-readable.
 
 ## CLI extensibility
 
-Let extensions register subcommands under `pid x ...` first, avoiding
-collisions with core commands.
+Current CLI accepts flexible positional arguments, so any new top-level word can
+change behavior for a branch with that name. API version 1 should therefore
+reserve only one extension namespace and document it clearly.
 
-Example:
+Recommended first namespace:
 
 ```sh
 pid x doctor
@@ -224,25 +310,47 @@ pid x jira link PID-123
 pid x templates list
 ```
 
-Later, allow top-level commands only with explicit config opt-in.
+Implementation notes:
+
+- Dispatch `pid x ...` before legacy workflow parsing, similar to current
+  `config`, `sessions`, and `version` info commands.
+- Treat `x` as a reserved command word once this ships.
+- Do not let extensions add arbitrary top-level `pid <command>` names in API
+  version 1.
+- Add compatibility tests proving all non-reserved legacy argument forms still
+  parse exactly as before.
+
+Later, allow top-level commands only with explicit config opt-in and release
+notes.
 
 ## Config extensibility
 
-Keep strict validation for core tables, but reserve extension namespace:
+Keep strict validation for core tables, but reserve an extension namespace:
 
 ```toml
+[extensions]
+enabled = ["my_extension"]
+paths = [".pid/extensions"]
+
 [extensions.my_extension]
 foo = "bar"
 ```
 
-Core validates only that extension config is TOML-compatible. Extension
-validates its own table and reports
-`pid: invalid [extensions.my_extension] ...`.
+Parser rules:
+
+- `enabled` is a list of extension names.
+- `paths` is a list of project-local extension directories.
+- Other subtables under `[extensions.<name>]` are raw extension config.
+- Core validates that extension config is TOML-compatible, but the extension
+  validates its own table and reports
+  `pid: invalid [extensions.my_extension] ...`.
+- Unknown keys inside existing core tables remain errors.
+- `pid config show` should include extension config after this table exists.
 
 ## Event stream
 
-Replace ad-hoc log strings with structured events, while still rendering nice
-text:
+Use one shared `pid.events.WorkflowEvent` model for both extensibility and the
+higher-level orchestrator plan:
 
 ```python
 WorkflowEvent(
@@ -252,12 +360,17 @@ WorkflowEvent(
 )
 ```
 
+The final event model may also include run ID, sequence, timestamp, level, and
+stage. The first implementation only needs enough structure to avoid parsing
+terminal output.
+
 Benefits:
 
 - JSON logs.
 - Notifications.
 - Replay/debug.
 - Extension hooks without parsing terminal output.
+- A shared foundation for the orchestrator agent roadmap.
 
 ## Stability policy
 
@@ -276,40 +389,54 @@ Extensions declare compatibility:
 api_version = "1"
 ```
 
+Incompatible extensions fail fast with a clear diagnostic before worktree
+creation.
+
 ## Incremental implementation plan
+
+### Phase 0: compatibility baseline
+
+- Run the existing test suite before refactoring.
+- Add characterization tests for legacy CLI parsing, output/exit codes, base
+  refresh, merge confirmation, and config validation that the refactor must not
+  change.
+- Decide and document the reserved command word for extension commands (`x`).
 
 ### Phase 1: refactor without behavior changes
 
 - Extract `WorkflowContext` from `PIDFlow` local variables.
-- Extract default workflow steps from `_run` into small functions.
-- Add tests proving current behavior unchanged.
-- Keep `run_pid(argv, config)` public behavior identical.
+- Move `Repository`, `Forge`, `SessionLogger`, and `KeepAwake` construction
+  behind context/service factories, while keeping defaults identical.
+- Extract default workflow steps from `_run` and `run_pr_loop` into small
+  functions.
+- Keep `run_pid(argv, config, output_mode)` public behavior identical.
 
-### Phase 2: internal step engine
+### Phase 2: internal step engine and events
 
 - Add `WorkflowStep` model with `name` and `run(ctx)`.
-- Execute built-in steps through ordered engine.
-- Add structured step events to session log.
+- Execute built-in steps through an ordered engine.
+- Add structured step events while preserving current session-log text.
 - No external extension loading yet.
 
-### Phase 3: hooks
+### Phase 3: internal hooks
 
 - Add hook registry.
-- Add `before/after/error` hook execution.
-- Add config table for local hooks disabled by default.
-- Test ordering, error handling, and stop behavior.
+- Add `before/after/error` hook execution around steps.
+- Allow tests to inject hooks directly.
+- Test ordering, error handling, stop behavior, and bounded retry behavior.
 
-### Phase 4: extension discovery
+### Phase 4: extension config and discovery
 
+- Add `[extensions] enabled = [...]` and `paths = [...]` config support.
 - Add entry point loading via `importlib.metadata.entry_points`.
-- Add `[extensions] enabled = [...]` config.
-- Add `pid extensions list` info command.
-- Fail fast on incompatible API versions.
+- Add project-local path loading after repo root resolution.
+- Add `pid extensions list` or `pid x extensions list` info command.
+- Fail fast on missing, duplicate, or incompatible API versions.
 
 ### Phase 5: replaceable services and policies
 
 - Define interfaces for `Agent`, `Forge`, `Repository`, `MessageGenerator`,
-  `ChecksPolicy`, and `MergePolicy`.
+  `ChecksPolicy`, `BaseRefreshPolicy`, `MergePolicy`, and `CleanupPolicy`.
 - Register built-ins as defaults.
 - Let extensions replace or wrap services.
 
@@ -318,6 +445,12 @@ api_version = "1"
 - Add `pid x <extension-command> ...` dispatcher.
 - Keep Typer core simple; extension commands receive argv/context.
 - Add docs and examples.
+
+### Phase 7: runnable examples and API docs
+
+- Add at least two runnable example extensions.
+- Document stable hook/step names, context fields, and trust boundaries.
+- Document migration guidance for config-only customizations to extensions.
 
 ## Good first extension examples
 
@@ -335,13 +468,20 @@ api_version = "1"
 - Hard debugging: emit structured events and show extension names in errors.
 - Unsafe hooks: run in-process by default, but document trust boundary. Local
   extensions are trusted code.
+- CLI collisions: reserve only `pid x` for extension commands in API version 1.
+- Local path ambiguity: resolve project-local extension paths from repo root and
+  load them before destructive steps.
 - Config sprawl: keep core defaults minimal and put bloat in extension packages.
 
 ## Definition of done
 
 - Core pid still works with zero config and zero extensions.
 - Default workflow behavior remains unchanged in tests.
+- Base refresh, merge retry, merge confirmation, and cleanup behavior remain
+  unchanged unless explicitly overridden by an extension.
 - User can install one package and enable it from config.
 - User can add project-local extension code without forking pid.
 - User can add a step, hook a built-in step, and replace a built-in step.
+- User can run an extension command under `pid x ...`.
 - Public extension API is documented with at least two runnable examples.
+- `mise run check` passes.

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -1,0 +1,225 @@
+# Extensions
+
+Extensions let trusted Python code customize pid without forking it. The API is
+versioned with `PID_EXTENSION_API = "1"`.
+
+## Enable extensions
+
+Install an extension package that exposes the `pid.extensions` entry point, then
+enable it in config:
+
+```toml
+[extensions]
+enabled = ["my_extension"]
+paths = []
+```
+
+For project-local extensions, put Python files in a configured directory:
+
+```toml
+[extensions]
+enabled = ["local_checks"]
+paths = [".pid/extensions"]
+
+[extensions.local_checks]
+command = "mise run check"
+```
+
+Relative `paths` are resolved from the repository root during normal workflow
+runs. Extension commands under `pid x ...` resolve relative paths from the repo
+root when available, otherwise from the current directory.
+
+## Extension protocol
+
+```python
+from pid.extensions import ExtensionRegistry, WorkflowStep
+
+class MyExtension:
+    name = "my_extension"
+    api_version = "1"
+
+    def register(self, registry: ExtensionRegistry) -> None:
+        registry.add_hook("before.run_initial_agent", before_initial)
+        registry.add_step(WorkflowStep("extra_check", extra_check), before="run_pr_loop")
+        registry.replace_step("run_review_agent", custom_review)
+        registry.add_cli_command("doctor", doctor)
+```
+
+An extension object can be exposed as:
+
+- an entry point object or class;
+- `extension = MyExtension()` in a local file;
+- `get_extension()` in a local file;
+- a local class with `name`, `api_version`, and `register()`.
+
+## Registry API
+
+- `add_hook(name, fn, *, order=0)`
+- `add_step(step, *, before=None, after=None)`
+- `replace_step(name, step)`
+- `disable_step(name)`
+- `add_policy(name, policy)`
+- `replace_service(name, factory)`
+- `add_cli_command(name, callback)`
+
+Hook order is deterministic: `order`, extension name, then registration order.
+Hooks and workflow steps must return `None` or `StepResult`; other return values
+stop the run with an extension diagnostic.
+
+## Built-in workflow steps
+
+Project-local extensions load after `resolve_repo_root`, then can hook, add, or
+replace these extension-aware steps:
+
+1. `require_commands`
+2. `resolve_main_worktree`
+3. `validate_clean_main_worktree`
+4. `resolve_default_branch`
+5. `update_default_branch`
+6. `capture_base_rev`
+7. `create_worktree`
+8. `trust_mise`
+9. `run_initial_agent`
+10. `inspect_initial_changes`
+11. `run_review_agent`
+12. `inspect_review_changes`
+13. `stop_if_no_changes`
+14. `generate_message`
+15. `verify_commit_title`
+16. `commit_changes`
+17. `run_pr_loop`
+
+Entry-point extensions load earlier and can also replace or disable bootstrap
+steps, but local extensions intentionally cannot change argument parsing or repo
+resolution.
+
+## Context
+
+Hooks and steps receive `WorkflowContext`. Common fields:
+
+- `ctx.config`
+- `ctx.extension_config`
+- `ctx.parsed`
+- `ctx.branch`
+- `ctx.repo_root`
+- `ctx.main_worktree`
+- `ctx.worktree_path`
+- `ctx.default_branch`
+- `ctx.base_rev`
+- `ctx.commit_message`
+- `ctx.runner`
+- `ctx.repository`
+- `ctx.forge`
+- `ctx.events`
+- `ctx.scratch`
+
+Useful helpers:
+
+- `ctx.require_parsed()`
+- `ctx.require_worktree()`
+- `ctx.repo_path()`
+- `ctx.set_commit_message(message)`
+- `ctx.emit(name, step="...", fields={...})`
+
+## Extension commands
+
+Extensions register commands under `pid x ...`:
+
+```python
+def doctor(ctx):
+    print("extension ok")
+    return 0
+
+class MyExtension:
+    name = "my_extension"
+    api_version = "1"
+
+    def register(self, registry):
+        registry.add_cli_command("doctor", doctor)
+```
+
+Run it:
+
+```sh
+pid x doctor
+```
+
+List enabled extensions:
+
+```sh
+pid x extensions list
+```
+
+## Example: JSON event log
+
+`.pid/extensions/json_log.py`:
+
+```python
+from pathlib import Path
+
+from pid.events import JsonlEventSink
+
+class JsonLogExtension:
+    name = "json_log"
+    api_version = "1"
+
+    def register(self, registry):
+        def install_sink(ctx):
+            path = Path(ctx.repo_root) / ".git" / "pid-events.jsonl"
+            ctx.events = JsonlEventSink(path)
+            return None
+
+        registry.add_hook("before.require_commands", install_sink)
+
+extension = JsonLogExtension()
+```
+
+Config:
+
+```toml
+[extensions]
+enabled = ["json_log"]
+paths = [".pid/extensions"]
+```
+
+## Example: local check before PR
+
+`.pid/extensions/local_checks.py`:
+
+```python
+from pid.extensions import StepResult, WorkflowStep
+from pid.output import write_command_output
+
+class LocalChecksExtension:
+    name = "local_checks"
+    api_version = "1"
+
+    def register(self, registry):
+        registry.add_step(
+            WorkflowStep("run_local_checks", run_local_checks),
+            before="run_pr_loop",
+        )
+
+
+def run_local_checks(ctx):
+    result = ctx.runner.run(["mise", "run", "check"], cwd=ctx.require_worktree())
+    if result.returncode != 0:
+        write_command_output(result)
+        return StepResult.stop(result.returncode, "local checks failed")
+    return None
+
+extension = LocalChecksExtension()
+```
+
+Config:
+
+```toml
+[extensions]
+enabled = ["local_checks"]
+paths = [".pid/extensions"]
+```
+
+## Trust boundary
+
+Extensions run in-process with full Python access to the repository and user
+environment. Only enable extensions you trust.

--- a/src/pid/cli.py
+++ b/src/pid/cli.py
@@ -9,9 +9,16 @@ from typing import Annotated
 import typer
 
 from pid import __version__
+from pid.commands import CommandRunner
 from pid.config import PIDConfig, init_config, load_config
 from pid.diagnostics import active_sessions_table, config_to_toml, print_config_metadata
 from pid.errors import PIDAbort
+from pid.extensions import (
+    ExtensionCommandContext,
+    ExtensionError,
+    ExtensionRegistry,
+    load_enabled_extensions,
+)
 from pid.interactive import resolve_interactive_args
 from pid.models import OutputMode
 from pid.output import echo_err, echo_out
@@ -26,6 +33,7 @@ APP_CONTEXT = {
 CONFIG_USAGE = "usage: pid config show|default|path"
 SESSIONS_USAGE = "usage: pid sessions [--all|-a]"
 VERSION_USAGE = "usage: pid version"
+X_USAGE = "usage: pid x <extension-command> [ARGS...]"
 
 app = typer.Typer(add_completion=False, context_settings=APP_CONTEXT)
 
@@ -90,6 +98,7 @@ def main(
 
     - pid sessions [--all|-a]
     - pid config show|default|path
+    - pid x <extension-command> [ARGS...]
     - pid version
     """
     raw_args = [*(args or []), *ctx.args]
@@ -160,6 +169,9 @@ def _run_info_command(raw_args: list[str], *, config_path: Path | None) -> int |
         echo_err(CONFIG_USAGE)
         return 2
 
+    if raw_args[0] == "x":
+        return _run_extension_command(raw_args[1:], config_path=config_path)
+
     if raw_args in (["sessions"], ["sessions", "list"]):
         typer.echo(active_sessions_table(), nl=False)
         return 0
@@ -181,4 +193,79 @@ def _run_info_command(raw_args: list[str], *, config_path: Path | None) -> int |
         echo_err(VERSION_USAGE)
         return 2
 
+    return None
+
+
+def _run_extension_command(raw_args: list[str], *, config_path: Path | None) -> int:
+    if not raw_args:
+        echo_err(X_USAGE)
+        return 2
+
+    try:
+        loaded_config = load_config(config_path)
+    except PIDAbort as error:
+        return error.code
+
+    registry = ExtensionRegistry()
+    repo_root = _optional_repo_root()
+    try:
+        load_enabled_extensions(
+            loaded_config.extensions,
+            registry,
+            repo_root=repo_root,
+            include_entry_points=True,
+            include_local=True,
+            fail_missing=True,
+        )
+    except ExtensionError as error:
+        echo_err(f"pid: {error}")
+        return 2
+
+    if raw_args in (["extensions", "list"], ["extensions"]):
+        typer.echo(_extensions_table(registry), nl=False)
+        return 0
+
+    command_name = raw_args[0]
+    callback = registry.cli_commands.get(command_name)
+    if callback is None:
+        echo_err(f"pid: unknown extension command: {command_name}")
+        echo_err(X_USAGE)
+        return 2
+
+    context = ExtensionCommandContext(
+        argv=raw_args[1:],
+        config=loaded_config,
+        registry=registry,
+        repo_root=repo_root,
+    )
+    try:
+        return callback(context) or 0
+    except PIDAbort as error:
+        return error.code
+    except ExtensionError as error:
+        echo_err(f"pid: {error}")
+        return 2
+    except Exception as error:  # noqa: BLE001 - extension command boundary
+        echo_err(
+            f"pid: extension command {command_name} failed: "
+            f"{type(error).__name__}: {error}"
+        )
+        return 1
+
+
+def _extensions_table(registry: ExtensionRegistry) -> str:
+    if not registry.extension_infos:
+        return "no enabled pid extensions\n"
+    lines = ["name  api  source"]
+    lines.append("----  ---  ------")
+    for info in registry.extension_infos:
+        lines.append(f"{info.name}  {info.api_version}    {info.source}")
+    return "\n".join(lines) + "\n"
+
+
+def _optional_repo_root() -> Path | None:
+    result = CommandRunner().run(["git", "rev-parse", "--show-toplevel"])
+    output = result.stdout.strip()
+    if result.returncode == 0 and output:
+        return Path(output)
     return None

--- a/src/pid/config.py
+++ b/src/pid/config.py
@@ -102,6 +102,10 @@ base_refresh_enabled = true
 base_refresh_stages = ["before_pr"]
 base_refresh_limit = 3
 base_refresh_agent_conflict_fix = true
+
+[extensions]
+enabled = []
+paths = []
 """
 
 MESSAGE_PROMPT_FIELDS = ("original_prompt", "branch", "base_rev", "output_path")
@@ -382,6 +386,15 @@ class WorkflowConfig:
 
 
 @dataclass(frozen=True)
+class ExtensionConfig:
+    """Extension loading and per-extension configuration."""
+
+    enabled: tuple[str, ...] = ()
+    paths: tuple[str, ...] = ()
+    config: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class PIDConfig:
     """Top-level pid config."""
 
@@ -391,6 +404,7 @@ class PIDConfig:
     forge: ForgeConfig = field(default_factory=ForgeConfig)
     prompts: PromptConfig = field(default_factory=PromptConfig)
     workflow: WorkflowConfig = field(default_factory=WorkflowConfig)
+    extensions: ExtensionConfig = field(default_factory=ExtensionConfig)
 
 
 def default_config_path() -> Path:
@@ -466,6 +480,7 @@ def parse_config(data: dict[str, Any], path: Path) -> PIDConfig:
         "forge",
         "prompts",
         "workflow",
+        "extensions",
     }
     if unknown_top:
         fail_config(path, f"unknown top-level key: {sorted(unknown_top)[0]}")
@@ -477,6 +492,7 @@ def parse_config(data: dict[str, Any], path: Path) -> PIDConfig:
         forge=parse_forge_config(data.get("forge", {}), path),
         prompts=parse_prompt_config(data.get("prompts", {}), path),
         workflow=parse_workflow_config(data.get("workflow", {}), path),
+        extensions=parse_extension_config(data.get("extensions", {}), path),
     )
 
 
@@ -933,6 +949,42 @@ def parse_workflow_config(data: Any, path: Path) -> WorkflowConfig:
         base_refresh_limit=base_refresh_limit,
         base_refresh_agent_conflict_fix=base_refresh_agent_conflict_fix,
     )
+
+
+def parse_extension_config(data: Any, path: Path) -> ExtensionConfig:
+    """Parse the reserved extension namespace.
+
+    Core validates loader controls and table shape only. Individual extensions
+    validate their own `[extensions.<name>]` table after loading.
+    """
+
+    if not isinstance(data, dict):
+        fail_config(path, "[extensions] must be a table")
+
+    allowed_scalars = {"enabled", "paths"}
+    enabled = string_tuple(data.get("enabled", ()), path, "extensions.enabled")
+    paths = string_tuple(data.get("paths", ()), path, "extensions.paths")
+
+    if not all(item.strip() for item in enabled):
+        fail_config(path, "extensions.enabled must not contain empty strings")
+    if not all(item.strip() for item in paths):
+        fail_config(path, "extensions.paths must not contain empty strings")
+    if len(set(enabled)) != len(enabled):
+        fail_config(path, "extensions.enabled must not contain duplicates")
+    if len(set(paths)) != len(paths):
+        fail_config(path, "extensions.paths must not contain duplicates")
+
+    extension_tables: dict[str, dict[str, Any]] = {}
+    for key, value in data.items():
+        if key in allowed_scalars:
+            continue
+        if not isinstance(value, dict):
+            fail_config(path, f"[extensions.{key}] must be a table")
+        if not key.strip():
+            fail_config(path, "extension config names must not be empty")
+        extension_tables[key] = value
+
+    return ExtensionConfig(enabled=enabled, paths=paths, config=extension_tables)
 
 
 def forge_args(

--- a/src/pid/context.py
+++ b/src/pid/context.py
@@ -1,0 +1,120 @@
+"""Typed runtime context for pid workflows and extensions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pid.commands import CommandRunner
+from pid.config import PIDConfig
+from pid.events import EventSink, NullEventSink, WorkflowEvent
+from pid.extensions import ExtensionRegistry
+from pid.github import Forge
+from pid.keepawake import KeepAwake
+from pid.models import CommitMessage, OutputMode, ParsedArgs
+from pid.repository import Repository
+from pid.session_logging import SessionLogger
+
+
+@dataclass
+class WorkflowContext:
+    """Explicit mutable state for one pid workflow run."""
+
+    argv: list[str]
+    config: PIDConfig
+    runner: CommandRunner
+    repository: Repository
+    forge: Forge
+    registry: ExtensionRegistry
+    output_mode: OutputMode = OutputMode.NORMAL
+    events: EventSink = field(default_factory=NullEventSink)
+    parsed: ParsedArgs | None = None
+    repo_root: str = ""
+    main_worktree: str = ""
+    worktree_path: str = ""
+    default_branch: str = ""
+    base_rev: str = ""
+    followup_thinking_level: str = ""
+    review_rejected_first_pass: bool = False
+    initial_commit_count: int = 0
+    initial_dirty: str = ""
+    pre_review_state_hash: str = ""
+    post_review_commit_count: int = 0
+    post_review_dirty: str = ""
+    commit_message: CommitMessage | None = None
+    commit_title: str = ""
+    rewritten_head: str = ""
+    pr_url: str = ""
+    pr_title: str = ""
+    checks_status: int = 0
+    checks_output: str = ""
+    attempt: int = 0
+    base_refresh_count: int = 0
+    base_refresh_stage_counts: dict[str, int] = field(default_factory=dict)
+    merge_retries: int = 0
+    session_logger: SessionLogger | None = None
+    keep_awake: KeepAwake | None = None
+    services: dict[str, Any] = field(default_factory=dict)
+    scratch: dict[str, Any] = field(default_factory=dict)
+    step_retries: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def extension_config(self) -> dict[str, dict[str, Any]]:
+        """Return raw per-extension config tables."""
+
+        return self.config.extensions.config
+
+    @property
+    def branch(self) -> str:
+        """Return parsed branch, or an empty string before argument parsing."""
+
+        return self.parsed.branch if self.parsed is not None else ""
+
+    def require_parsed(self) -> ParsedArgs:
+        """Return parsed args or raise when called too early."""
+
+        if self.parsed is None:
+            raise RuntimeError("workflow arguments are not parsed yet")
+        return self.parsed
+
+    def require_worktree(self) -> str:
+        """Return worktree path or raise when no worktree exists yet."""
+
+        if not self.worktree_path:
+            raise RuntimeError("workflow worktree is not available yet")
+        return self.worktree_path
+
+    def repo_path(self) -> Path:
+        """Return the repository root as a path."""
+
+        if not self.repo_root:
+            raise RuntimeError("repository root is not available yet")
+        return Path(self.repo_root)
+
+    def set_commit_message(self, message: CommitMessage) -> None:
+        """Set generated commit/PR metadata."""
+
+        self.commit_message = message
+        self.pr_title = message.title
+
+    def emit(
+        self,
+        name: str,
+        *,
+        step: str = "",
+        level: str = "info",
+        message: str = "",
+        fields: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit a structured workflow event."""
+
+        self.events.emit(
+            WorkflowEvent(
+                name=name,
+                step=step,
+                level=level,
+                message=message,
+                fields=fields or {},
+            )
+        )

--- a/src/pid/diagnostics.py
+++ b/src/pid/diagnostics.py
@@ -29,12 +29,28 @@ def config_to_toml(config: PIDConfig) -> str:
     lines: list[str] = []
     for section in fields(config):
         value = getattr(config, section.name)
+        if section.name == "extensions":
+            lines.extend(_extensions_to_toml(value))
+            continue
         lines.append(f"[{section.name}]")
         for item in fields(value):
             item_value = getattr(value, item.name)
             lines.append(f"{item.name} = {_toml_value(item_value)}")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def _extensions_to_toml(value: Any) -> list[str]:
+    lines = ["[extensions]"]
+    lines.append(f"enabled = {_toml_value(value.enabled)}")
+    lines.append(f"paths = {_toml_value(value.paths)}")
+    lines.append("")
+    for name, table in value.config.items():
+        lines.append(f"[extensions.{name}]")
+        for key, item_value in table.items():
+            lines.append(f"{key} = {_toml_value(item_value)}")
+        lines.append("")
+    return lines
 
 
 def print_config_metadata(*, config_path: Path | None = None) -> str:
@@ -152,10 +168,15 @@ def _toml_value(value: Any) -> str:
         return "true" if value else "false"
     if isinstance(value, int):
         return str(value)
+    if isinstance(value, float):
+        return str(value)
     if isinstance(value, str):
         return json.dumps(value)
     if isinstance(value, tuple | list):
         return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    if isinstance(value, dict):
+        items = [f"{key} = {_toml_value(item)}" for key, item in value.items()]
+        return "{ " + ", ".join(items) + " }"
     if is_dataclass(value) and not isinstance(value, type):
         return _toml_value(dataclasses.asdict(value))
     raise TypeError(f"unsupported TOML value: {value!r}")

--- a/src/pid/events.py
+++ b/src/pid/events.py
@@ -1,0 +1,103 @@
+"""Structured workflow events for pid."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol, TextIO
+
+
+@dataclass(frozen=True)
+class WorkflowEvent:
+    """A structured workflow event emitted by core and extensions."""
+
+    name: str
+    step: str = ""
+    level: str = "info"
+    message: str = ""
+    fields: dict[str, Any] = field(default_factory=dict)
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(UTC).isoformat(timespec="milliseconds")
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable event dictionary."""
+
+        data: dict[str, Any] = {
+            "timestamp": self.timestamp,
+            "name": self.name,
+            "level": self.level,
+        }
+        if self.step:
+            data["step"] = self.step
+        if self.message:
+            data["message"] = self.message
+        if self.fields:
+            data["fields"] = self.fields
+        return data
+
+    def to_json(self) -> str:
+        """Serialize the event as one compact JSON object."""
+
+        return json.dumps(self.to_dict(), sort_keys=True, default=str)
+
+
+class EventSink(Protocol):
+    """Receiver for structured workflow events."""
+
+    def emit(self, event: WorkflowEvent) -> None:
+        """Handle a workflow event."""
+
+
+class NullEventSink:
+    """Event sink that intentionally drops every event."""
+
+    def emit(self, event: WorkflowEvent) -> None:
+        _ = event
+
+
+class JsonlEventSink:
+    """Append workflow events to a JSONL file or text stream."""
+
+    def __init__(self, target: Path | str | TextIO) -> None:
+        self._stream: TextIO | None = None
+        self._path: Path | None = None
+        if isinstance(target, Path | str):
+            self._path = Path(target)
+        else:
+            self._stream = target
+
+    def emit(self, event: WorkflowEvent) -> None:
+        line = event.to_json() + "\n"
+        if self._stream is not None:
+            self._stream.write(line)
+            self._stream.flush()
+            return
+        if self._path is None:  # pragma: no cover - constructor prevents this
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("a", encoding="utf-8") as stream:
+            stream.write(line)
+
+
+class CompositeEventSink:
+    """Fan out events to multiple sinks."""
+
+    def __init__(self, *sinks: EventSink) -> None:
+        self.sinks = sinks
+
+    def emit(self, event: WorkflowEvent) -> None:
+        for sink in self.sinks:
+            sink.emit(event)
+
+
+class ListEventSink:
+    """In-memory event sink useful for tests and embedding."""
+
+    def __init__(self) -> None:
+        self.events: list[WorkflowEvent] = []
+
+    def emit(self, event: WorkflowEvent) -> None:
+        self.events.append(event)

--- a/src/pid/extensions.py
+++ b/src/pid/extensions.py
@@ -1,0 +1,494 @@
+"""Extension API and loader for pid."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import inspect
+import sys
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from pid.errors import abort
+from pid.output import echo_err
+
+PID_EXTENSION_API = "1"
+ENTRY_POINT_GROUP = "pid.extensions"
+
+
+class ExtensionError(RuntimeError):
+    """Raised when extension registration or execution fails."""
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """Result returned by workflow steps and hooks."""
+
+    action: str = "continue"
+    code: int = 0
+    reason: str = ""
+
+    @classmethod
+    def continue_(cls) -> StepResult:
+        return cls("continue")
+
+    @classmethod
+    def skip(cls, reason: str = "") -> StepResult:
+        return cls("skip", reason=reason)
+
+    @classmethod
+    def stop(cls, code: int = 0, reason: str = "") -> StepResult:
+        return cls("stop", code=code, reason=reason)
+
+    @classmethod
+    def retry(cls, reason: str = "") -> StepResult:
+        return cls("retry", reason=reason)
+
+
+StepHandler = Callable[[Any], StepResult | None]
+HookHandler = Callable[[Any], StepResult | None]
+ServiceFactory = Callable[[Any], Any]
+Policy = Any
+ExtensionCommand = Callable[[Any], int | None]
+
+
+@dataclass(frozen=True)
+class WorkflowStep:
+    """Named workflow step callable."""
+
+    name: str
+    run: StepHandler
+
+
+@dataclass(frozen=True)
+class HookRegistration:
+    """Registered hook callback with deterministic ordering metadata."""
+
+    hook: str
+    fn: HookHandler
+    order: int
+    extension_name: str
+    registration_index: int
+
+
+@dataclass(frozen=True)
+class ExtensionCommandContext:
+    """Context passed to extension CLI commands."""
+
+    argv: list[str]
+    config: Any
+    registry: ExtensionRegistry
+    repo_root: Path | None = None
+    scratch: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExtensionInfo:
+    """Loaded extension metadata."""
+
+    name: str
+    source: str
+    api_version: str
+
+
+class Extension(Protocol):
+    """Stable extension protocol."""
+
+    name: str
+    api_version: str
+
+    def register(self, registry: ExtensionRegistry) -> None:
+        """Register hooks, steps, services, policies, or commands."""
+
+
+@dataclass(frozen=True)
+class _StepInsertion:
+    step: WorkflowStep
+    before: str | None
+    after: str | None
+    registration_index: int
+
+
+class ExtensionRegistry:
+    """Registry populated by built-ins and extensions."""
+
+    def __init__(self) -> None:
+        self.hooks: dict[str, list[HookRegistration]] = {}
+        self.replaced_steps: dict[str, WorkflowStep] = {}
+        self.disabled_steps: set[str] = set()
+        self.added_steps: list[_StepInsertion] = []
+        self.policies: dict[str, Policy] = {}
+        self.service_factories: dict[str, ServiceFactory] = {}
+        self.cli_commands: dict[str, ExtensionCommand] = {}
+        self.extension_infos: list[ExtensionInfo] = []
+        self.loaded_extension_names: set[str] = set()
+        self._current_extension = "core"
+        self._registration_index = 0
+
+    def add_hook(self, name: str, fn: HookHandler, *, order: int = 0) -> None:
+        """Register a hook callback."""
+
+        self._require_name(name, "hook")
+        self._registration_index += 1
+        self.hooks.setdefault(name, []).append(
+            HookRegistration(
+                hook=name,
+                fn=fn,
+                order=order,
+                extension_name=self._current_extension,
+                registration_index=self._registration_index,
+            )
+        )
+
+    def add_step(
+        self,
+        step: WorkflowStep | StepHandler,
+        *,
+        name: str = "",
+        before: str | None = None,
+        after: str | None = None,
+    ) -> None:
+        """Add a step before or after an existing step, or append it."""
+
+        if before and after:
+            raise ExtensionError("add_step accepts only one of before or after")
+        workflow_step = self._coerce_step(step, name=name)
+        self._registration_index += 1
+        self.added_steps.append(
+            _StepInsertion(workflow_step, before, after, self._registration_index)
+        )
+
+    def replace_step(
+        self, name: str, step: WorkflowStep | StepHandler, *, step_name: str = ""
+    ) -> None:
+        """Replace a built-in step by name."""
+
+        self._require_name(name, "step")
+        workflow_step = self._coerce_step(step, name=step_name or name)
+        self.replaced_steps[name] = workflow_step
+
+    def disable_step(self, name: str) -> None:
+        """Disable a built-in or extension-added step by name."""
+
+        self._require_name(name, "step")
+        self.disabled_steps.add(name)
+
+    def add_policy(self, name: str, policy: Policy) -> None:
+        """Register a named policy object."""
+
+        self._require_name(name, "policy")
+        if name in self.policies:
+            raise ExtensionError(f"policy already registered: {name}")
+        self.policies[name] = policy
+
+    def replace_service(self, name: str, factory: ServiceFactory) -> None:
+        """Replace or wrap a named service using a context-aware factory."""
+
+        self._require_name(name, "service")
+        self.service_factories[name] = factory
+
+    def add_cli_command(self, name: str, callback: ExtensionCommand) -> None:
+        """Register a command under `pid x <name>`.
+
+        The callback receives an `ExtensionCommandContext` and returns an exit
+        code or `None` for success.
+        """
+
+        self._require_name(name, "CLI command")
+        if name in self.cli_commands:
+            raise ExtensionError(f"CLI command already registered: {name}")
+        self.cli_commands[name] = callback
+
+    def resolve_steps(
+        self,
+        default_steps: Iterable[WorkflowStep],
+        *,
+        known_steps: Iterable[str] = (),
+    ) -> list[WorkflowStep]:
+        """Return default steps after applying extension modifications."""
+
+        steps = list(default_steps)
+        self._validate_unique_steps(steps)
+        default_names = {step.name for step in steps}
+        known_step_names = set(known_steps)
+        missing_replacements = (
+            set(self.replaced_steps) - default_names - known_step_names
+        )
+        if missing_replacements:
+            missing = sorted(missing_replacements)[0]
+            raise ExtensionError(f"cannot replace unknown step: {missing}")
+
+        resolved: list[WorkflowStep] = []
+        for step in steps:
+            if step.name in self.disabled_steps:
+                continue
+            resolved.append(self.replaced_steps.get(step.name, step))
+
+        for insertion in sorted(
+            self.added_steps, key=lambda item: item.registration_index
+        ):
+            if insertion.step.name in self.disabled_steps:
+                continue
+            names = [step.name for step in resolved]
+            if insertion.step.name in names:
+                raise ExtensionError(f"step already registered: {insertion.step.name}")
+            if insertion.before is not None:
+                if insertion.before not in names:
+                    raise ExtensionError(
+                        f"cannot add step before unknown step: {insertion.before}"
+                    )
+                resolved.insert(names.index(insertion.before), insertion.step)
+                continue
+            if insertion.after is not None:
+                if insertion.after not in names:
+                    raise ExtensionError(
+                        f"cannot add step after unknown step: {insertion.after}"
+                    )
+                resolved.insert(names.index(insertion.after) + 1, insertion.step)
+                continue
+            resolved.append(insertion.step)
+
+        self._validate_unique_steps(resolved)
+        return resolved
+
+    def run_hooks(self, name: str, ctx: Any) -> StepResult:
+        """Run registered hooks and return the first non-continue result."""
+
+        registrations = sorted(
+            self.hooks.get(name, ()),
+            key=lambda item: (
+                item.order,
+                item.extension_name,
+                item.registration_index,
+            ),
+        )
+        for registration in registrations:
+            try:
+                result = registration.fn(ctx)
+            except Exception as error:  # noqa: BLE001 - extension boundary
+                raise ExtensionError(
+                    f"extension {registration.extension_name} hook {name} failed: "
+                    f"{type(error).__name__}: {error}"
+                ) from error
+            step_result = normalize_step_result(result)
+            if step_result.action != "continue":
+                return step_result
+        return StepResult.continue_()
+
+    def register_extension(self, extension: Any, *, source: str) -> None:
+        """Register one loaded extension object."""
+
+        name = getattr(extension, "name", "")
+        api_version = getattr(extension, "api_version", "")
+        if not isinstance(name, str) or not name.strip():
+            raise ExtensionError(f"extension from {source} has no valid name")
+        if api_version != PID_EXTENSION_API:
+            raise ExtensionError(
+                f"extension {name} uses unsupported API version {api_version!r}; "
+                f"expected {PID_EXTENSION_API!r}"
+            )
+        if name in self.loaded_extension_names:
+            raise ExtensionError(f"extension already loaded: {name}")
+        if not hasattr(extension, "register"):
+            raise ExtensionError(f"extension {name} has no register() method")
+
+        previous_extension = self._current_extension
+        self._current_extension = name
+        try:
+            extension.register(self)
+        except Exception as error:  # noqa: BLE001 - extension boundary
+            raise ExtensionError(
+                f"extension {name} registration failed: {type(error).__name__}: {error}"
+            ) from error
+        finally:
+            self._current_extension = previous_extension
+
+        self.loaded_extension_names.add(name)
+        self.extension_infos.append(ExtensionInfo(name, source, api_version))
+
+    @staticmethod
+    def _require_name(name: str, kind: str) -> None:
+        if not name or not name.strip():
+            raise ExtensionError(f"{kind} name must not be empty")
+
+    @staticmethod
+    def _coerce_step(step: WorkflowStep | StepHandler, *, name: str) -> WorkflowStep:
+        if isinstance(step, WorkflowStep):
+            return step
+        if not name:
+            raise ExtensionError("step name required")
+        return WorkflowStep(name, step)
+
+    @staticmethod
+    def _validate_unique_steps(steps: list[WorkflowStep]) -> None:
+        seen: set[str] = set()
+        for step in steps:
+            if not step.name.strip():
+                raise ExtensionError("step name must not be empty")
+            if step.name in seen:
+                raise ExtensionError(f"step already registered: {step.name}")
+            seen.add(step.name)
+
+
+def normalize_step_result(result: StepResult | None) -> StepResult:
+    """Normalize `None` step results to continue and reject invalid values."""
+
+    if result is None:
+        return StepResult.continue_()
+    if isinstance(result, StepResult):
+        return result
+    raise ExtensionError(
+        "workflow steps and hooks must return StepResult or None; "
+        f"got {type(result).__name__}"
+    )
+
+
+def load_enabled_extensions(
+    extension_config: Any,
+    registry: ExtensionRegistry,
+    *,
+    repo_root: Path | None = None,
+    include_entry_points: bool = True,
+    include_local: bool = True,
+    fail_missing: bool = True,
+) -> None:
+    """Load enabled extensions from entry points and configured local paths."""
+
+    if include_entry_points:
+        load_entry_point_extensions(extension_config, registry)
+    if include_local:
+        load_local_extensions(extension_config, registry, repo_root=repo_root)
+    if fail_missing:
+        ensure_enabled_extensions_loaded(extension_config, registry)
+
+
+def load_entry_point_extensions(
+    extension_config: Any, registry: ExtensionRegistry
+) -> None:
+    """Load enabled extensions exposed through Python entry points."""
+
+    enabled = _enabled_names(extension_config)
+    if not enabled:
+        return
+    for entry_point in _entry_points():
+        if (
+            entry_point.name not in enabled
+            or entry_point.name in registry.loaded_extension_names
+        ):
+            continue
+        try:
+            loaded = entry_point.load()
+            extension = _coerce_extension_object(loaded)
+            registry.register_extension(
+                extension, source=f"entry-point:{entry_point.name}"
+            )
+        except ExtensionError:
+            raise
+        except Exception as error:  # noqa: BLE001 - extension boundary
+            raise ExtensionError(
+                f"could not load extension {entry_point.name}: "
+                f"{type(error).__name__}: {error}"
+            ) from error
+
+
+def load_local_extensions(
+    extension_config: Any,
+    registry: ExtensionRegistry,
+    *,
+    repo_root: Path | None,
+) -> None:
+    """Load enabled project-local extensions from configured directories."""
+
+    enabled = _enabled_names(extension_config)
+    if not enabled:
+        return
+    for configured_path in getattr(extension_config, "paths", ()):
+        path = Path(configured_path)
+        if not path.is_absolute():
+            path = (repo_root or Path.cwd()) / path
+        if not path.exists():
+            raise ExtensionError(f"extension path does not exist: {path}")
+        if not path.is_dir():
+            raise ExtensionError(f"extension path is not a directory: {path}")
+        for file_path in sorted(path.glob("*.py")):
+            if file_path.name.startswith("_"):
+                continue
+            module = _load_module_from_path(file_path)
+            for extension in _extensions_from_module(module):
+                name = getattr(extension, "name", "")
+                if name in enabled and name not in registry.loaded_extension_names:
+                    registry.register_extension(extension, source=f"local:{file_path}")
+
+
+def ensure_enabled_extensions_loaded(
+    extension_config: Any, registry: ExtensionRegistry
+) -> None:
+    """Fail when an enabled extension was not found in any source."""
+
+    enabled = _enabled_names(extension_config)
+    missing = enabled - registry.loaded_extension_names
+    if missing:
+        raise ExtensionError(f"enabled extension not found: {sorted(missing)[0]}")
+
+
+def abort_extension_error(error: ExtensionError) -> None:
+    """Print a consistent extension diagnostic and abort."""
+
+    echo_err(f"pid: {error}")
+    abort(2)
+
+
+def _enabled_names(extension_config: Any) -> set[str]:
+    return set(getattr(extension_config, "enabled", ()))
+
+
+def _entry_points() -> list[importlib.metadata.EntryPoint]:
+    entry_points = importlib.metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        return list(entry_points.select(group=ENTRY_POINT_GROUP))
+    return list(entry_points.get(ENTRY_POINT_GROUP, ()))  # type: ignore[attr-defined]
+
+
+def _coerce_extension_object(loaded: Any) -> Any:
+    if inspect.isclass(loaded):
+        return loaded()
+    if callable(loaded) and not hasattr(loaded, "register"):
+        return loaded()
+    return loaded
+
+
+def _load_module_from_path(path: Path) -> Any:
+    module_name = f"pid_local_extension_{abs(hash(path))}_{path.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ExtensionError(f"could not load extension module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as error:  # noqa: BLE001 - extension boundary
+        raise ExtensionError(
+            f"could not load extension module {path}: {type(error).__name__}: {error}"
+        ) from error
+    return module
+
+
+def _extensions_from_module(module: Any) -> list[Any]:
+    extensions: list[Any] = []
+    if hasattr(module, "extension"):
+        extensions.append(_coerce_extension_object(module.extension))
+    if hasattr(module, "get_extension"):
+        extensions.append(_coerce_extension_object(module.get_extension))
+    for _name, value in inspect.getmembers(module, inspect.isclass):
+        if value is _ProtocolSentinel:
+            continue
+        if value.__module__ != module.__name__:
+            continue
+        if hasattr(value, "register") and hasattr(value, "name"):
+            extensions.append(_coerce_extension_object(value))
+    return extensions
+
+
+_ProtocolSentinel = Extension

--- a/src/pid/workflow.py
+++ b/src/pid/workflow.py
@@ -9,7 +9,18 @@ from pathlib import Path
 
 from pid.commands import CommandRunner, require_command
 from pid.config import PIDConfig
+from pid.context import WorkflowContext
 from pid.errors import PIDAbort, abort
+from pid.events import EventSink, NullEventSink
+from pid.extensions import (
+    ExtensionError,
+    ExtensionRegistry,
+    StepResult,
+    WorkflowStep,
+    abort_extension_error,
+    load_enabled_extensions,
+    normalize_step_result,
+)
 from pid.github import Forge
 from pid.keepawake import KeepAwake
 from pid.messages import parse_commit_message
@@ -49,16 +60,32 @@ class PIDFlow:
         runner: CommandRunner | None = None,
         config: PIDConfig | None = None,
         output_mode: OutputMode = OutputMode.NORMAL,
+        registry: ExtensionRegistry | None = None,
+        events: EventSink | None = None,
+        load_extensions: bool = True,
     ) -> None:
         self.runner = runner or CommandRunner()
         self.runner.set_output_mode(output_mode)
         self.config = config or PIDConfig()
+        self.registry = registry or ExtensionRegistry()
+        if load_extensions:
+            try:
+                load_enabled_extensions(
+                    self.config.extensions,
+                    self.registry,
+                    include_local=False,
+                    fail_missing=False,
+                )
+            except ExtensionError as error:
+                abort_extension_error(error)
+        self.events = events or NullEventSink()
         self.repository = Repository(self.runner)
         self.forge = Forge(self.runner, self.config.forge)
         self.review_rejected_first_pass = False
         self.session_logger: SessionLogger | None = None
         self.keep_awake: KeepAwake | None = None
         self.output_mode = output_mode
+        self.context: WorkflowContext | None = None
 
     def run(self, argv: list[str]) -> int:
         exit_code = 0
@@ -66,6 +93,11 @@ class PIDFlow:
             self._run(argv)
         except PIDAbort as error:
             exit_code = error.code
+        except ExtensionError as error:
+            exit_code = 2
+            echo_err(f"pid: {error}")
+            if self.session_logger is not None:
+                self.session_logger.event(f"extension error: {error}")
         except Exception as error:
             exit_code = 1
             if self.session_logger is not None:
@@ -85,13 +117,179 @@ class PIDFlow:
         return exit_code
 
     def _run(self, argv: list[str]) -> None:
+        ctx = WorkflowContext(
+            argv=argv,
+            config=self.config,
+            runner=self.runner,
+            repository=self.repository,
+            forge=self.forge,
+            registry=self.registry,
+            output_mode=self.output_mode,
+            events=self.events,
+        )
+        self.context = ctx
+        ctx.emit("workflow.created")
+        try:
+            bootstrap_steps = self.bootstrap_steps()
+            for step in bootstrap_steps:
+                self.run_workflow_step(ctx, step)
+            self.load_project_extensions(ctx)
+            self.apply_service_replacements(ctx)
+            for step in self.registry.resolve_steps(
+                self.default_steps(),
+                known_steps=(step.name for step in bootstrap_steps),
+            ):
+                self.run_workflow_step(ctx, step)
+            ctx.emit("workflow.completed")
+        except Exception as error:
+            ctx.emit(
+                "workflow.failed",
+                level="error",
+                fields={"error": f"{type(error).__name__}: {error}"},
+            )
+            raise
+
+    def bootstrap_steps(self) -> list[WorkflowStep]:
+        """Return fixed pre-extension steps needed to find project extensions."""
+
+        return [
+            WorkflowStep("parse_args", self.step_parse_args),
+            WorkflowStep("start_session_logging", self.step_start_session_logging),
+            WorkflowStep("start_keep_awake", self.step_start_keep_awake),
+            WorkflowStep("render_run_summary", self.step_render_run_summary),
+            WorkflowStep("validate_branch", self.step_validate_branch),
+            WorkflowStep("resolve_repo_root", self.step_resolve_repo_root),
+        ]
+
+    def default_steps(self) -> list[WorkflowStep]:
+        """Return extension-aware steps after repository resolution."""
+
+        return [
+            WorkflowStep("require_commands", self.step_require_commands),
+            WorkflowStep("resolve_main_worktree", self.step_resolve_main_worktree),
+            WorkflowStep(
+                "validate_clean_main_worktree",
+                self.step_validate_clean_main_worktree,
+            ),
+            WorkflowStep("resolve_default_branch", self.step_resolve_default_branch),
+            WorkflowStep("update_default_branch", self.step_update_default_branch),
+            WorkflowStep("capture_base_rev", self.step_capture_base_rev),
+            WorkflowStep("create_worktree", self.step_create_worktree),
+            WorkflowStep("trust_mise", self.step_trust_mise),
+            WorkflowStep("run_initial_agent", self.step_run_initial_agent),
+            WorkflowStep("inspect_initial_changes", self.step_inspect_initial_changes),
+            WorkflowStep("run_review_agent", self.step_run_review_agent),
+            WorkflowStep("inspect_review_changes", self.step_inspect_review_changes),
+            WorkflowStep("stop_if_no_changes", self.step_stop_if_no_changes),
+            WorkflowStep("generate_message", self.step_generate_message),
+            WorkflowStep("verify_commit_title", self.step_verify_commit_title),
+            WorkflowStep("commit_changes", self.step_commit_changes),
+            WorkflowStep("run_pr_loop", self.step_run_pr_loop),
+        ]
+
+    def run_workflow_step(self, ctx: WorkflowContext, step: WorkflowStep) -> None:
+        """Run one step with hooks, events, replacements, and bounded retry."""
+
+        if step.name in self.registry.disabled_steps:
+            return
+        step = self.registry.replaced_steps.get(step.name, step)
+        retries = 0
+        while True:
+            ctx.emit("step.started", step=step.name)
+            before_result = self.registry.run_hooks(f"before.{step.name}", ctx)
+            if before_result.action == "skip":
+                ctx.emit("step.skipped", step=step.name, message=before_result.reason)
+                return
+            self.handle_step_result(before_result)
+            try:
+                result = normalize_step_result(step.run(ctx))
+            except Exception as error:
+                ctx.emit(
+                    "step.failed",
+                    step=step.name,
+                    level="error",
+                    fields={"error": f"{type(error).__name__}: {error}"},
+                )
+                error_result = self.registry.run_hooks(f"error.{step.name}", ctx)
+                if error_result.action != "continue":
+                    self.handle_step_result(error_result)
+                raise
+            after_result = self.registry.run_hooks(f"after.{step.name}", ctx)
+            if after_result.action != "continue":
+                result = after_result
+            if result.action == "retry":
+                retries += 1
+                if retries > 3:
+                    echo_err(f"pid: step retry limit reached: {step.name}")
+                    abort(1)
+                ctx.emit("step.retrying", step=step.name, message=result.reason)
+                continue
+            self.handle_step_result(result)
+            ctx.emit("step.completed", step=step.name)
+            return
+
+    @staticmethod
+    def handle_step_result(result: StepResult) -> None:
+        """Apply a step or hook result."""
+
+        if result.action == "continue" or result.action == "skip":
+            return
+        if result.action == "stop":
+            abort(result.code)
+        if result.action == "retry":
+            return
+        raise ExtensionError(f"unknown step result action: {result.action}")
+
+    def load_project_extensions(self, ctx: WorkflowContext) -> None:
+        """Load configured project-local extensions after repo resolution."""
+
+        load_enabled_extensions(
+            self.config.extensions,
+            self.registry,
+            repo_root=Path(ctx.repo_root),
+            include_entry_points=False,
+            include_local=True,
+            fail_missing=True,
+        )
+
+    def apply_service_replacements(self, ctx: WorkflowContext) -> None:
+        """Apply extension-provided service replacements before preflight."""
+
+        for name, factory in self.registry.service_factories.items():
+            service = factory(ctx)
+            ctx.services[name] = service
+            if name == "runner":
+                self.runner = service
+                self.runner.set_output_mode(self.output_mode)
+                if self.session_logger is not None:
+                    self.runner.set_logger(self.session_logger)
+                ctx.runner = service
+            elif name == "repository":
+                self.repository = service
+                ctx.repository = service
+            elif name == "forge":
+                self.forge = service
+                ctx.forge = service
+
+    def step_parse_args(self, ctx: WorkflowContext) -> None:
         parsed = parse_args(
-            argv,
+            ctx.argv,
             default_thinking=self.config.agent.default_thinking,
             thinking_levels=self.config.agent.thinking_levels,
         )
-        self.start_session_logging(argv)
+        ctx.parsed = parsed
+        ctx.followup_thinking_level = parsed.thinking_level
+
+    def step_start_session_logging(self, ctx: WorkflowContext) -> None:
+        self.start_session_logging(ctx.argv)
+        ctx.session_logger = self.session_logger
+
+    def step_start_keep_awake(self, ctx: WorkflowContext) -> None:
         self.start_keep_awake()
+        ctx.keep_awake = self.keep_awake
+
+    def step_render_run_summary(self, ctx: WorkflowContext) -> None:
+        parsed = ctx.require_parsed()
         self.log_parsed_args(parsed)
         print_run_summary(
             parsed,
@@ -99,69 +297,97 @@ class PIDFlow:
             forge_label=self.config.forge.label,
             output_mode=self.output_mode,
         )
-        followup_thinking_level = parsed.thinking_level
-
         print_phase("Prepare", "validate repo, branch, tools")
-        validate_branch_name(self.runner, parsed.branch)
 
-        repo_root = self.resolve_repo_root()
+    def step_validate_branch(self, ctx: WorkflowContext) -> None:
+        validate_branch_name(self.runner, ctx.require_parsed().branch)
 
+    def step_resolve_repo_root(self, ctx: WorkflowContext) -> None:
+        ctx.repo_root = self.resolve_repo_root()
+
+    def step_require_commands(self, ctx: WorkflowContext) -> None:
+        _ = ctx
         self.require_external_commands()
 
-        main_worktree = self.resolve_main_worktree()
+    def step_resolve_main_worktree(self, ctx: WorkflowContext) -> None:
+        ctx.main_worktree = self.resolve_main_worktree()
 
+    def step_validate_clean_main_worktree(self, ctx: WorkflowContext) -> None:
         main_dirty = self.repository.output(
-            ["status", "--porcelain", "--untracked-files=all"], cwd=main_worktree
+            ["status", "--porcelain", "--untracked-files=all"],
+            cwd=ctx.main_worktree,
         )
         if has_output(main_dirty):
             echo_err(
-                f"pid: main worktree has uncommitted or untracked changes: {main_worktree}"
+                "pid: main worktree has uncommitted or untracked changes: "
+                f"{ctx.main_worktree}"
             )
             abort(1)
 
-        default_branch = self.repository.default_branch(
-            main_worktree, fallback=self.forge.default_branch
+    def step_resolve_default_branch(self, ctx: WorkflowContext) -> None:
+        ctx.default_branch = self.repository.default_branch(
+            ctx.main_worktree, fallback=self.forge.default_branch
         )
-        self.repository.switch_and_update_default_branch(main_worktree, default_branch)
-        base_rev = self.repository.output(
-            ["rev-parse", "HEAD"], cwd=main_worktree
+
+    def step_update_default_branch(self, ctx: WorkflowContext) -> None:
+        self.repository.switch_and_update_default_branch(
+            ctx.main_worktree, ctx.default_branch
+        )
+
+    def step_capture_base_rev(self, ctx: WorkflowContext) -> None:
+        ctx.base_rev = self.repository.output(
+            ["rev-parse", "HEAD"], cwd=ctx.main_worktree
         ).strip()
 
-        worktree_path = worktree_path_for(repo_root, parsed.branch)
-        self.repository.guard_new_worktree(main_worktree, parsed.branch, worktree_path)
-        self.repository.create_worktree(
-            main_worktree, worktree_path, parsed.branch, base_rev
+    def step_create_worktree(self, ctx: WorkflowContext) -> None:
+        parsed = ctx.require_parsed()
+        ctx.worktree_path = worktree_path_for(ctx.repo_root, parsed.branch)
+        self.repository.guard_new_worktree(
+            ctx.main_worktree, parsed.branch, ctx.worktree_path
         )
+        self.repository.create_worktree(
+            ctx.main_worktree, ctx.worktree_path, parsed.branch, ctx.base_rev
+        )
+        echo_out(f"Created {ctx.worktree_path} on branch {parsed.branch}")
 
-        echo_out(f"Created {worktree_path} on branch {parsed.branch}")
-
+    def step_trust_mise(self, ctx: WorkflowContext) -> None:
         if self.config.workflow.trust_mise and shutil.which("mise") is not None:
-            self.runner.require(["mise", "trust", "."], cwd=worktree_path)
+            self.runner.require(["mise", "trust", "."], cwd=ctx.worktree_path)
 
+    def step_run_initial_agent(self, ctx: WorkflowContext) -> None:
+        parsed = ctx.require_parsed()
         print_phase("Agent", "create initial changes")
         if parsed.interactive:
             self.run_agent_session(
                 parsed.interactive_prompt,
-                cwd=worktree_path,
+                cwd=ctx.worktree_path,
                 thinking_level=parsed.thinking_level,
             )
-        else:
-            self.run_agent_prompt(
-                parsed.prompt,
-                cwd=worktree_path,
-                thinking_level=parsed.thinking_level,
-                failure_context="stopping before review/commit/PR",
-                step_label=f"{self.config.agent.label} initial",
-            )
-
-        initial_commit_count = self.repository.count_commits(base_rev, worktree_path)
-        initial_dirty = self.repository.output(
-            ["status", "--porcelain", "--untracked-files=all"], cwd=worktree_path
+            return
+        self.run_agent_prompt(
+            parsed.prompt,
+            cwd=ctx.worktree_path,
+            thinking_level=parsed.thinking_level,
+            failure_context="stopping before review/commit/PR",
+            step_label=f"{self.config.agent.label} initial",
         )
-        pre_review_state_hash = self.repository.state_hash(worktree_path)
 
+    def step_inspect_initial_changes(self, ctx: WorkflowContext) -> None:
+        ctx.initial_commit_count = self.repository.count_commits(
+            ctx.base_rev, ctx.worktree_path
+        )
+        ctx.initial_dirty = self.repository.output(
+            ["status", "--porcelain", "--untracked-files=all"],
+            cwd=ctx.worktree_path,
+        )
+        ctx.pre_review_state_hash = self.repository.state_hash(ctx.worktree_path)
+
+    def step_run_review_agent(self, ctx: WorkflowContext) -> None:
+        parsed = ctx.require_parsed()
         review_target = review_target_for(
-            base_rev, initial_commit_count, has_output(initial_dirty)
+            ctx.base_rev,
+            ctx.initial_commit_count,
+            has_output(ctx.initial_dirty),
         )
         print_phase("Review", review_target.replace("_", " "))
         review_prompt = build_review_prompt(
@@ -171,61 +397,83 @@ class PIDFlow:
         )
         self.run_agent_prompt(
             review_prompt,
-            cwd=worktree_path,
+            cwd=ctx.worktree_path,
             thinking_level=self.config.agent.review_thinking,
             failure_context="stopping before commit/PR",
             label=f"{self.config.agent.label} review",
             step_label=f"{self.config.agent.label} review",
         )
 
-        post_review_state_hash = self.repository.state_hash(worktree_path)
-        if pre_review_state_hash != post_review_state_hash:
+    def step_inspect_review_changes(self, ctx: WorkflowContext) -> None:
+        post_review_state_hash = self.repository.state_hash(ctx.worktree_path)
+        if ctx.pre_review_state_hash != post_review_state_hash:
             self.review_rejected_first_pass = True
+            ctx.review_rejected_first_pass = True
             echo_out(
                 "pid: review changed first pass; follow-up "
-                f"{self.config.agent.label} will keep thinking {followup_thinking_level}"
+                f"{self.config.agent.label} will keep thinking "
+                f"{ctx.followup_thinking_level}"
             )
 
-        post_review_commit_count = self.repository.count_commits(
-            base_rev, worktree_path
+        ctx.post_review_commit_count = self.repository.count_commits(
+            ctx.base_rev, ctx.worktree_path
         )
-        post_review_dirty = self.repository.output(
-            ["status", "--porcelain", "--untracked-files=all"], cwd=worktree_path
+        ctx.post_review_dirty = self.repository.output(
+            ["status", "--porcelain", "--untracked-files=all"],
+            cwd=ctx.worktree_path,
         )
-        if post_review_commit_count == 0 and not has_output(post_review_dirty):
+
+    def step_stop_if_no_changes(self, ctx: WorkflowContext) -> None:
+        if ctx.post_review_commit_count == 0 and not has_output(ctx.post_review_dirty):
             echo_out("pid: no changes or commits after agent; stopping before PR")
             abort(0)
 
+    def step_generate_message(self, ctx: WorkflowContext) -> None:
         print_phase("Message + commit", "generate metadata and create commit")
         commit_message = self.generate_commit_message(
-            parsed=parsed,
-            base_rev=base_rev,
-            worktree_path=worktree_path,
+            parsed=ctx.require_parsed(),
+            base_rev=ctx.base_rev,
+            worktree_path=ctx.worktree_path,
         )
-        self.verify_commit_title(commit_message)
+        ctx.set_commit_message(commit_message)
 
+    def step_verify_commit_title(self, ctx: WorkflowContext) -> None:
+        if ctx.commit_message is None:
+            raise RuntimeError("commit message has not been generated")
+        self.verify_commit_title(ctx.commit_message)
+
+    def step_commit_changes(self, ctx: WorkflowContext) -> None:
+        if ctx.commit_message is None:
+            raise RuntimeError("commit message has not been generated")
         pre_commit_head = self.repository.output(
-            ["rev-parse", "HEAD"], cwd=worktree_path
+            ["rev-parse", "HEAD"], cwd=ctx.worktree_path
         ).strip()
-        self.repository.commit_initial_changes(base_rev, worktree_path, commit_message)
+        self.repository.commit_initial_changes(
+            ctx.base_rev, ctx.worktree_path, ctx.commit_message
+        )
         post_commit_head = self.repository.output(
-            ["rev-parse", "HEAD"], cwd=worktree_path
+            ["rev-parse", "HEAD"], cwd=ctx.worktree_path
         ).strip()
-        rewritten_head = pre_commit_head if pre_commit_head != post_commit_head else ""
-        commit_title = self.repository.output(
-            ["log", "-1", "--format=%s"], cwd=worktree_path
+        ctx.rewritten_head = (
+            pre_commit_head if pre_commit_head != post_commit_head else ""
+        )
+        ctx.commit_title = self.repository.output(
+            ["log", "-1", "--format=%s"], cwd=ctx.worktree_path
         ).strip()
 
+    def step_run_pr_loop(self, ctx: WorkflowContext) -> None:
+        if ctx.commit_message is None:
+            raise RuntimeError("commit message has not been generated")
         self.run_pr_loop(
-            parsed=parsed,
-            base_rev=base_rev,
-            commit_message=commit_message,
-            commit_title=commit_title,
-            rewritten_head=rewritten_head,
-            followup_thinking_level=followup_thinking_level,
-            main_worktree=main_worktree,
-            default_branch=default_branch,
-            worktree_path=worktree_path,
+            parsed=ctx.require_parsed(),
+            base_rev=ctx.base_rev,
+            commit_message=ctx.commit_message,
+            commit_title=ctx.commit_title,
+            rewritten_head=ctx.rewritten_head,
+            followup_thinking_level=ctx.followup_thinking_level,
+            main_worktree=ctx.main_worktree,
+            default_branch=ctx.default_branch,
+            worktree_path=ctx.worktree_path,
         )
 
     def start_session_logging(self, argv: list[str]) -> None:
@@ -1081,7 +1329,14 @@ def run_pid(
     *,
     config: PIDConfig | None = None,
     output_mode: OutputMode = OutputMode.NORMAL,
+    registry: ExtensionRegistry | None = None,
+    events: EventSink | None = None,
 ) -> int:
     """Run the pid flow and return a process exit code."""
 
-    return PIDFlow(config=config, output_mode=output_mode).run(argv)
+    return PIDFlow(
+        config=config,
+        output_mode=output_mode,
+        registry=registry,
+        events=events,
+    ).run(argv)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,788 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pid.cli import app
+from pid.config import ExtensionConfig, parse_config
+from pid.events import JsonlEventSink, WorkflowEvent
+from pid.errors import PIDAbort
+from pid.extensions import ExtensionError, ExtensionRegistry, StepResult, WorkflowStep
+from pid.models import CommandResult
+from pid.workflow import PIDFlow, command_diagnostic
+from tests.fakes import assert_success, base_state, run_pid
+
+
+DEMO_EXTENSION = "\n".join(
+    [
+        "from pid.extensions import WorkflowStep",
+        "from pid.output import echo_out",
+        "",
+        "def before_initial(ctx):",
+        "    echo_out(f'demo before {ctx.branch}')",
+        "",
+        "def extra_step(ctx):",
+        "    echo_out('demo extra step')",
+        "",
+        "def replace_review(ctx):",
+        "    echo_out('demo review replacement')",
+        "",
+        "def doctor(ctx):",
+        "    echo_out('doctor ' + ' '.join(ctx.argv))",
+        "    return 0",
+        "",
+        "class DemoExtension:",
+        "    name = 'demo'",
+        "    api_version = '1'",
+        "    def register(self, registry):",
+        "        registry.add_hook('before.run_initial_agent', before_initial)",
+        "        registry.add_step(WorkflowStep('demo_extra_step', extra_step), after='run_initial_agent')",
+        "        registry.replace_step('run_review_agent', replace_review)",
+        "        registry.add_cli_command('doctor', doctor)",
+        "",
+        "extension = DemoExtension()",
+        "",
+    ]
+)
+
+
+def test_registry_adds_replaces_disables_steps_and_orders_hooks() -> None:
+    registry = ExtensionRegistry()
+    seen: list[str] = []
+
+    def step(name: str):
+        return lambda _ctx: seen.append(name)
+
+    registry.add_step(WorkflowStep("middle", step("middle")), after="one")
+    registry.replace_step("two", WorkflowStep("two", step("two-replaced")))
+    registry.disable_step("three")
+    registry.add_hook("before.one", lambda _ctx: seen.append("late"), order=10)
+    registry.add_hook("before.one", lambda _ctx: seen.append("early"), order=-10)
+
+    steps = registry.resolve_steps(
+        [
+            WorkflowStep("one", step("one")),
+            WorkflowStep("two", step("two")),
+            WorkflowStep("three", step("three")),
+        ]
+    )
+
+    assert [item.name for item in steps] == ["one", "middle", "two"]
+    registry.run_hooks("before.one", object())
+    for item in steps:
+        item.run(object())
+    assert seen == ["early", "late", "one", "middle", "two-replaced"]
+
+
+def test_hook_can_stop_workflow() -> None:
+    registry = ExtensionRegistry()
+    registry.add_hook("before.step", lambda _ctx: StepResult.stop(7, "blocked"))
+
+    result = registry.run_hooks("before.step", object())
+
+    assert result == StepResult.stop(7, "blocked")
+    assert StepResult.skip("nope").action == "skip"
+    assert StepResult.retry("again").action == "retry"
+
+
+def test_workflow_event_jsonl_sink_serializes_events() -> None:
+    stream = io.StringIO()
+    sink = JsonlEventSink(stream)
+
+    sink.emit(WorkflowEvent("step.started", step="run_review_agent", fields={"x": 1}))
+
+    data = json.loads(stream.getvalue())
+    assert data["fields"] == {"x": 1}
+    assert data["level"] == "info"
+    assert data["name"] == "step.started"
+    assert data["step"] == "run_review_agent"
+    assert data["timestamp"]
+
+
+def test_extension_config_parses_loader_controls_and_raw_tables(tmp_path: Path) -> None:
+    config = parse_config(
+        {
+            "extensions": {
+                "enabled": ["demo"],
+                "paths": [".pid/extensions"],
+                "demo": {"flag": True, "label": "Demo"},
+            }
+        },
+        tmp_path / "config.toml",
+    )
+
+    assert config.extensions == ExtensionConfig(
+        enabled=("demo",),
+        paths=(".pid/extensions",),
+        config={"demo": {"flag": True, "label": "Demo"}},
+    )
+
+
+def test_project_local_extension_can_hook_add_and_replace_workflow_steps(
+    tmp_path: Path,
+) -> None:
+    extension_dir = tmp_path / "extensions"
+    extension_dir.mkdir()
+    (extension_dir / "demo.py").write_text(DEMO_EXTENSION)
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f"""
+[extensions]
+enabled = ["demo"]
+paths = ["{extension_dir}"]
+""".strip()
+    )
+    state = base_state(tmp_path)
+
+    process, final_state = run_pid(
+        tmp_path,
+        ["--config", str(config_path), "feature/cool-stuff", "prompt"],
+        state=state,
+    )
+
+    assert_success(process)
+    assert "demo before feature/cool-stuff" in process.stdout
+    assert "demo extra step" in process.stdout
+    assert "demo review replacement" in process.stdout
+    assert [call["kind"] for call in final_state["pi_calls"]] == [
+        "initial",
+        "message",
+    ]
+
+
+def test_pid_x_dispatches_project_local_extension_command(tmp_path: Path) -> None:
+    extension_dir = tmp_path / "extensions"
+    extension_dir.mkdir()
+    (extension_dir / "demo.py").write_text(DEMO_EXTENSION)
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f"""
+[extensions]
+enabled = ["demo"]
+paths = ["{extension_dir}"]
+""".strip()
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["--config", str(config_path), "x", "doctor", "alpha", "beta"],
+    )
+
+    assert result.exit_code == 0
+    assert "doctor alpha beta" in result.output
+
+
+def test_registry_reports_invalid_step_and_command_registration() -> None:
+    registry = ExtensionRegistry()
+
+    def noop(_ctx):
+        return None
+
+    errors = []
+    for action in (
+        lambda: registry.add_hook("", noop),
+        lambda: registry.add_step(noop),
+        lambda: registry.add_step(
+            WorkflowStep("both", noop), before="one", after="two"
+        ),
+        lambda: registry.add_policy("", object()),
+        lambda: registry.replace_service("", noop),
+        lambda: registry.add_cli_command("", noop),
+    ):
+        try:
+            action()
+        except Exception as error:  # noqa: BLE001 - asserting public errors
+            errors.append(str(error))
+
+    registry.add_policy("policy", object())
+    registry.add_cli_command("cmd", noop)
+    for action in (
+        lambda: registry.add_policy("policy", object()),
+        lambda: registry.add_cli_command("cmd", noop),
+    ):
+        try:
+            action()
+        except Exception as error:  # noqa: BLE001 - asserting public errors
+            errors.append(str(error))
+
+    assert any("hook name" in message for message in errors)
+    assert any("step name required" in message for message in errors)
+    assert any("only one of before or after" in message for message in errors)
+    assert any("policy already registered" in message for message in errors)
+    assert any("CLI command already registered" in message for message in errors)
+
+
+def test_registry_resolve_steps_reports_invalid_modifications() -> None:
+    registry = ExtensionRegistry()
+    registry.replace_step("missing", WorkflowStep("missing", lambda _ctx: None))
+
+    try:
+        registry.resolve_steps([WorkflowStep("one", lambda _ctx: None)])
+    except Exception as error:  # noqa: BLE001 - asserting public errors
+        assert "cannot replace unknown step" in str(error)
+    else:  # pragma: no cover
+        raise AssertionError("expected error")
+
+    duplicate = ExtensionRegistry()
+    try:
+        duplicate.resolve_steps(
+            [
+                WorkflowStep("one", lambda _ctx: None),
+                WorkflowStep("one", lambda _ctx: None),
+            ]
+        )
+    except Exception as error:  # noqa: BLE001 - asserting public errors
+        assert "step already registered" in str(error)
+
+    before = ExtensionRegistry()
+    before.add_step(WorkflowStep("extra", lambda _ctx: None), before="missing")
+    try:
+        before.resolve_steps([WorkflowStep("one", lambda _ctx: None)])
+    except Exception as error:  # noqa: BLE001 - asserting public errors
+        assert "before unknown step" in str(error)
+
+    after = ExtensionRegistry()
+    after.add_step(WorkflowStep("extra", lambda _ctx: None), after="missing")
+    try:
+        after.resolve_steps([WorkflowStep("one", lambda _ctx: None)])
+    except Exception as error:  # noqa: BLE001 - asserting public errors
+        assert "after unknown step" in str(error)
+
+
+def test_registry_register_extension_validation_and_hook_errors() -> None:
+    registry = ExtensionRegistry()
+
+    class Valid:
+        name = "valid"
+        api_version = "1"
+
+        def register(self, registry):
+            registry.add_hook(
+                "before.demo",
+                lambda _ctx: (_ for _ in ()).throw(ValueError("boom")),
+            )
+
+    class BadApi:
+        name = "bad-api"
+        api_version = "2"
+
+        def register(self, registry):
+            return None
+
+    class BadRegister:
+        name = "bad-register"
+        api_version = "1"
+
+        def register(self, registry):
+            raise RuntimeError("nope")
+
+    registry.register_extension(Valid(), source="test")
+    assert registry.loaded_extension_names == {"valid"}
+    try:
+        registry.run_hooks("before.demo", object())
+    except Exception as error:  # noqa: BLE001 - asserting public errors
+        assert "hook before.demo failed" in str(error)
+
+    for extension, message in (
+        (object(), "no valid name"),
+        (BadApi(), "unsupported API version"),
+        (Valid(), "already loaded"),
+        (BadRegister(), "registration failed"),
+    ):
+        try:
+            registry.register_extension(extension, source="test")
+        except Exception as error:  # noqa: BLE001 - asserting public errors
+            assert message in str(error)
+        else:  # pragma: no cover
+            raise AssertionError("expected error")
+
+
+def test_extension_loader_supports_entry_points_and_local_get_extension(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from pid.extensions import load_enabled_extensions
+
+    class EntryPointExtension:
+        name = "entry"
+        api_version = "1"
+
+        def register(self, registry):
+            registry.add_cli_command("entry", lambda _ctx: 0)
+
+    class FakeEntryPoint:
+        name = "entry"
+
+        def load(self):
+            return EntryPointExtension
+
+    monkeypatch.setattr("pid.extensions._entry_points", lambda: [FakeEntryPoint()])
+    local_dir = tmp_path / "local"
+    local_dir.mkdir()
+    local_extension = "\n".join(
+        [
+            "class LocalExtension:",
+            "    name = 'local'",
+            "    api_version = '1'",
+            "    def register(self, registry):",
+            "        registry.add_cli_command('local', lambda _ctx: 0)",
+            "",
+            "def get_extension():",
+            "    return LocalExtension()",
+            "",
+        ]
+    )
+    (local_dir / "local_ext.py").write_text(local_extension)
+    config = ExtensionConfig(
+        enabled=("entry", "local"), paths=(str(local_dir),), config={}
+    )
+    registry = ExtensionRegistry()
+
+    load_enabled_extensions(config, registry, repo_root=tmp_path)
+
+    assert registry.loaded_extension_names == {"entry", "local"}
+    assert set(registry.cli_commands) == {"entry", "local"}
+
+
+def test_extension_loader_reports_missing_paths_modules_and_enabled_names(
+    tmp_path: Path,
+) -> None:
+    from pid.extensions import load_enabled_extensions
+
+    for config, message in (
+        (
+            ExtensionConfig(enabled=("missing",), paths=(), config={}),
+            "enabled extension not found",
+        ),
+        (
+            ExtensionConfig(
+                enabled=("missing",), paths=(str(tmp_path / "missing"),), config={}
+            ),
+            "extension path does not exist",
+        ),
+    ):
+        try:
+            load_enabled_extensions(config, ExtensionRegistry(), repo_root=tmp_path)
+        except Exception as error:  # noqa: BLE001 - asserting public errors
+            assert message in str(error)
+        else:  # pragma: no cover
+            raise AssertionError("expected error")
+
+    not_dir = tmp_path / "file.py"
+    not_dir.write_text("")
+    try:
+        load_enabled_extensions(
+            ExtensionConfig(enabled=("x",), paths=(str(not_dir),), config={}),
+            ExtensionRegistry(),
+            repo_root=tmp_path,
+        )
+    except Exception as error:  # noqa: BLE001 - asserting public errors
+        assert "not a directory" in str(error)
+
+    bad_dir = tmp_path / "bad"
+    bad_dir.mkdir()
+    (bad_dir / "bad.py").write_text("raise RuntimeError('boom')")
+    try:
+        load_enabled_extensions(
+            ExtensionConfig(enabled=("bad",), paths=(str(bad_dir),), config={}),
+            ExtensionRegistry(),
+            repo_root=tmp_path,
+        )
+    except Exception as error:  # noqa: BLE001 - asserting public errors
+        assert "could not load extension module" in str(error)
+
+
+def test_event_sinks_and_context_helpers(tmp_path: Path) -> None:
+    from pid.commands import CommandRunner
+    from pid.context import WorkflowContext
+    from pid.events import CompositeEventSink, ListEventSink, NullEventSink
+    from pid.github import Forge
+    from pid.models import CommitMessage, ParsedArgs
+    from pid.repository import Repository
+
+    event = WorkflowEvent("demo", message="hello")
+    NullEventSink().emit(event)
+    first = ListEventSink()
+    second = ListEventSink()
+    CompositeEventSink(first, second).emit(event)
+    assert first.events == [event]
+    assert second.events == [event]
+
+    path = tmp_path / "events" / "events.jsonl"
+    JsonlEventSink(path).emit(event)
+    assert json.loads(path.read_text())["message"] == "hello"
+
+    runner = CommandRunner()
+    config = parse_config({}, tmp_path / "config.toml")
+    context = WorkflowContext(
+        argv=["feature/x", "prompt"],
+        config=config,
+        runner=runner,
+        repository=Repository(runner),
+        forge=Forge(runner, config.forge),
+        registry=ExtensionRegistry(),
+        events=first,
+    )
+    assert context.extension_config == {}
+    assert context.branch == ""
+    for helper in (context.require_parsed, context.require_worktree, context.repo_path):
+        try:
+            helper()
+        except RuntimeError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("expected RuntimeError")
+    context.parsed = ParsedArgs(3, "medium", "feature/x", "prompt", False, None)
+    context.repo_root = str(tmp_path)
+    context.worktree_path = str(tmp_path / "worktree")
+    context.set_commit_message(CommitMessage("feat: x", "body"))
+    context.emit("custom")
+    assert context.branch == "feature/x"
+    assert context.require_parsed().branch == "feature/x"
+    assert context.require_worktree().endswith("worktree")
+    assert context.repo_path() == tmp_path
+    assert context.pr_title == "feat: x"
+    assert first.events[-1].name == "custom"
+
+
+def test_pid_x_builtin_errors_and_extensions_list(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    missing = runner.invoke(app, ["x"])
+    assert missing.exit_code == 2
+    assert "usage: pid x" in missing.stderr
+
+    listed = runner.invoke(app, ["x", "extensions", "list"])
+    assert listed.exit_code == 0
+    assert "no enabled pid extensions" in listed.output
+
+    unknown = runner.invoke(app, ["x", "missing"])
+    assert unknown.exit_code == 2
+    assert "unknown extension command" in unknown.stderr
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("[extensions]\nenabled = ['missing']\n")
+    bad_config = runner.invoke(app, ["--config", str(config_path), "x", "missing"])
+    assert bad_config.exit_code == 2
+    assert "enabled extension not found" in bad_config.stderr
+
+
+def test_extension_command_errors_are_mapped_to_exit_codes(tmp_path: Path) -> None:
+    extension_dir = tmp_path / "extensions"
+    extension_dir.mkdir()
+    fail_extension = "\n".join(
+        [
+            "from pid.errors import abort",
+            "from pid.extensions import ExtensionError",
+            "def abort_cmd(ctx):",
+            "    abort(5)",
+            "def extension_error(ctx):",
+            "    raise ExtensionError('bad extension')",
+            "def boom(ctx):",
+            "    raise RuntimeError('boom')",
+            "class FailExtension:",
+            "    name = 'fail'",
+            "    api_version = '1'",
+            "    def register(self, registry):",
+            "        registry.add_cli_command('abort', abort_cmd)",
+            "        registry.add_cli_command('extension-error', extension_error)",
+            "        registry.add_cli_command('boom', boom)",
+            "extension = FailExtension()",
+            "",
+        ]
+    )
+    (extension_dir / "fail.py").write_text(fail_extension)
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f"[extensions]\nenabled = ['fail']\npaths = ['{extension_dir}']\n"
+    )
+    runner = CliRunner()
+
+    assert (
+        runner.invoke(app, ["--config", str(config_path), "x", "abort"]).exit_code == 5
+    )
+    extension_error = runner.invoke(
+        app, ["--config", str(config_path), "x", "extension-error"]
+    )
+    assert extension_error.exit_code == 2
+    assert "bad extension" in extension_error.stderr
+    boom = runner.invoke(app, ["--config", str(config_path), "x", "boom"])
+    assert boom.exit_code == 1
+    assert "extension command boom failed" in boom.stderr
+
+
+def test_invalid_extension_config_is_rejected(tmp_path: Path, capsys) -> None:
+    from pid.errors import PIDAbort
+
+    invalid_cases = [
+        ({"extensions": []}, "[extensions] must be a table"),
+        ({"extensions": {"enabled": ["demo", "demo"]}}, "duplicates"),
+        ({"extensions": {"paths": [""]}}, "empty strings"),
+        ({"extensions": {"demo": "bad"}}, "[extensions.demo] must be a table"),
+    ]
+
+    for data, message in invalid_cases:
+        try:
+            parse_config(data, tmp_path / "config.toml")
+        except PIDAbort as error:
+            assert error.code == 2
+            assert message in capsys.readouterr().err
+        else:  # pragma: no cover
+            raise AssertionError("expected config error")
+
+
+def test_pid_flow_step_runner_handles_extension_results_and_errors(
+    tmp_path: Path,
+) -> None:
+    from pid.commands import CommandRunner
+    from pid.context import WorkflowContext
+    from pid.github import Forge
+    from pid.repository import Repository
+
+    config = parse_config({}, tmp_path / "config.toml")
+    runner = CommandRunner()
+    flow = PIDFlow(runner=runner, config=config, load_extensions=False)
+    context = WorkflowContext(
+        argv=["feature/x", "prompt"],
+        config=config,
+        runner=runner,
+        repository=Repository(runner),
+        forge=Forge(runner, config.forge),
+        registry=flow.registry,
+    )
+    seen: list[str] = []
+
+    flow.registry.disable_step("disabled")
+    flow.run_workflow_step(
+        context, WorkflowStep("disabled", lambda _ctx: seen.append("bad"))
+    )
+    assert seen == []
+
+    flow.registry.add_hook("before.skipped", lambda _ctx: StepResult.skip("skip it"))
+    flow.run_workflow_step(
+        context, WorkflowStep("skipped", lambda _ctx: seen.append("bad"))
+    )
+    assert seen == []
+
+    retries = {"count": 0}
+
+    def retry_once(_ctx):
+        retries["count"] += 1
+        return StepResult.retry("again") if retries["count"] == 1 else None
+
+    flow.run_workflow_step(context, WorkflowStep("retry_once", retry_once))
+    assert retries["count"] == 2
+
+    flow.registry.add_hook("after.after_stop", lambda _ctx: StepResult.stop(6))
+    with pytest.raises(PIDAbort) as stop_info:
+        flow.run_workflow_step(context, WorkflowStep("after_stop", lambda _ctx: None))
+    assert stop_info.value.code == 6
+
+    flow.registry.add_hook("error.failing", lambda _ctx: seen.append("error hook"))
+    with pytest.raises(ValueError):
+        flow.run_workflow_step(
+            context,
+            WorkflowStep(
+                "failing", lambda _ctx: (_ for _ in ()).throw(ValueError("boom"))
+            ),
+        )
+    assert "error hook" in seen
+
+    with pytest.raises(PIDAbort) as retry_limit_info:
+        flow.run_workflow_step(
+            context, WorkflowStep("retry_forever", lambda _ctx: StepResult.retry())
+        )
+    assert retry_limit_info.value.code == 1
+
+    with pytest.raises(ExtensionError, match="StepResult or None"):
+        flow.run_workflow_step(context, WorkflowStep("bad_result", lambda _ctx: 42))
+
+    flow.registry.add_hook("before.bad_hook_result", lambda _ctx: "bad")
+    with pytest.raises(ExtensionError, match="StepResult or None"):
+        flow.run_workflow_step(
+            context, WorkflowStep("bad_hook_result", lambda _ctx: None)
+        )
+
+    flow.handle_step_result(StepResult.retry())
+    with pytest.raises(ExtensionError):
+        flow.handle_step_result(StepResult("unknown"))
+
+
+def test_pid_flow_applies_service_replacements(tmp_path: Path) -> None:
+    from pid.commands import CommandRunner
+    from pid.context import WorkflowContext
+    from pid.github import Forge
+    from pid.repository import Repository
+
+    config = parse_config({}, tmp_path / "config.toml")
+    runner = CommandRunner()
+    flow = PIDFlow(runner=runner, config=config, load_extensions=False)
+    context = WorkflowContext(
+        argv=["feature/x", "prompt"],
+        config=config,
+        runner=runner,
+        repository=Repository(runner),
+        forge=Forge(runner, config.forge),
+        registry=flow.registry,
+    )
+    new_runner = CommandRunner()
+    new_repository = Repository(new_runner)
+    new_forge = Forge(new_runner, config.forge)
+    flow.registry.replace_service("runner", lambda _ctx: new_runner)
+    flow.registry.replace_service("repository", lambda _ctx: new_repository)
+    flow.registry.replace_service("forge", lambda _ctx: new_forge)
+
+    flow.apply_service_replacements(context)
+
+    assert flow.runner is new_runner
+    assert flow.repository is new_repository
+    assert flow.forge is new_forge
+    assert context.services == {
+        "runner": new_runner,
+        "repository": new_repository,
+        "forge": new_forge,
+    }
+
+
+def test_pid_flow_maps_extension_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_load(*_args, **_kwargs):
+        raise ExtensionError("bad load")
+
+    monkeypatch.setattr("pid.workflow.load_enabled_extensions", fail_load)
+    with pytest.raises(PIDAbort) as exc_info:
+        PIDFlow(config=parse_config({}, Path("config.toml")))
+    assert exc_info.value.code == 2
+
+    flow = PIDFlow(config=parse_config({}, Path("config.toml")), load_extensions=False)
+    monkeypatch.setattr(
+        flow,
+        "_run",
+        lambda _argv: (_ for _ in ()).throw(ExtensionError("bad run")),
+    )
+    assert flow.run(["feature/x", "prompt"]) == 2
+
+
+def test_registry_resolve_steps_covers_before_append_and_duplicate_insertions() -> None:
+    before = ExtensionRegistry()
+    before.add_step(WorkflowStep("zero", lambda _ctx: None), before="one")
+    before.add_step(WorkflowStep("tail", lambda _ctx: None))
+    assert [
+        step.name
+        for step in before.resolve_steps([WorkflowStep("one", lambda _ctx: None)])
+    ] == [
+        "zero",
+        "one",
+        "tail",
+    ]
+
+    duplicate = ExtensionRegistry()
+    duplicate.add_step(WorkflowStep("one", lambda _ctx: None))
+    with pytest.raises(ExtensionError):
+        duplicate.resolve_steps([WorkflowStep("one", lambda _ctx: None)])
+
+    empty = ExtensionRegistry()
+    with pytest.raises(ExtensionError):
+        empty.resolve_steps([WorkflowStep("", lambda _ctx: None)])
+
+    disabled = ExtensionRegistry()
+    disabled.add_step(WorkflowStep("extra", lambda _ctx: None), after="one")
+    disabled.disable_step("extra")
+    assert [
+        step.name
+        for step in disabled.resolve_steps([WorkflowStep("one", lambda _ctx: None)])
+    ] == ["one"]
+
+
+def test_extension_loader_edge_cases(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from pid.extensions import (
+        _entry_points,
+        abort_extension_error,
+        load_enabled_extensions,
+    )
+
+    class NoRegister:
+        name = "no-register"
+        api_version = "1"
+
+    with pytest.raises(ExtensionError):
+        ExtensionRegistry().register_extension(NoRegister(), source="test")
+
+    class OtherEntryPoint:
+        name = "other"
+
+        def load(self):
+            raise AssertionError("should be skipped")
+
+    class BadEntryPoint:
+        name = "bad"
+
+        def load(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "pid.extensions._entry_points", lambda: [OtherEntryPoint(), BadEntryPoint()]
+    )
+    with pytest.raises(ExtensionError) as bad_load:
+        load_enabled_extensions(
+            ExtensionConfig(enabled=("bad",), paths=(), config={}), ExtensionRegistry()
+        )
+    assert "could not load extension bad" in str(bad_load.value)
+
+    class OldEntryPoints(dict):
+        def select(self, **_kwargs):
+            raise AttributeError
+
+    monkeypatch.setattr(
+        "pid.extensions.importlib.metadata.entry_points",
+        lambda: {"pid.extensions": [OtherEntryPoint()]},
+    )
+    assert _entry_points()[0].name == "other"
+
+    local_dir = tmp_path / "relative"
+    local_dir.mkdir()
+    (local_dir / "_ignored.py").write_text("raise RuntimeError('ignored')")
+    (local_dir / "class_ext.py").write_text(
+        "class ClassExtension:\n"
+        "    name = 'classy'\n"
+        "    api_version = '1'\n"
+        "    def register(self, registry):\n"
+        "        registry.add_cli_command('classy', lambda _ctx: 0)\n"
+    )
+    registry = ExtensionRegistry()
+    load_enabled_extensions(
+        ExtensionConfig(enabled=("classy",), paths=("relative",), config={}),
+        registry,
+        repo_root=tmp_path,
+        include_entry_points=False,
+    )
+    assert "classy" in registry.cli_commands
+
+    with pytest.raises(PIDAbort):
+        abort_extension_error(ExtensionError("bad"))
+
+
+def test_pid_x_lists_loaded_extensions(tmp_path: Path) -> None:
+    extension_dir = tmp_path / "extensions"
+    extension_dir.mkdir()
+    (extension_dir / "demo.py").write_text(DEMO_EXTENSION)
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f"[extensions]\nenabled = ['demo']\npaths = ['{extension_dir}']\n"
+    )
+
+    result = CliRunner().invoke(
+        app, ["--config", str(config_path), "x", "extensions", "list"]
+    )
+
+    assert result.exit_code == 0
+    assert "demo" in result.output
+    assert "local:" in result.output
+
+
+def test_command_diagnostic_joins_stdout_and_stderr_with_newline() -> None:
+    assert command_diagnostic(CommandResult(1, "out", "err")) == "out\nerr"


### PR DESCRIPTION
- Added extension configuration and loaders for entry points and local paths, including validation and enabled-extension checks.
- Introduced extension registry APIs for hooks, workflow step edits, service replacement, policies, CLI commands, context, and structured events.
- Refactored the workflow into named steps with validated step results so extensions can continue, skip, stop, retry, insert, replace, or disable behavior safely.
- Added `pid x` command dispatch/listing plus documentation and tests covering extension loading, CLI behavior, events, config parsing, and step-result errors.