### PR TITLE
feat: expose PR loop extension points

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,9 +340,12 @@ auto-merge, pid polls for up to `workflow.merge_confirmation_timeout_seconds`
 seconds before cleaning up. If confirmation times out, pid exits nonzero and
 leaves the PR/worktree for manual follow-up.
 
-Extensions can hook, add, replace, or disable workflow steps and can register
-commands under `pid x ...`. See [docs/EXTENSIONS.md](docs/EXTENSIONS.md) for the
-API, trust boundary, and runnable local-extension examples.
+Extensions can hook, add, replace, or disable workflow steps, including
+fine-grained PR-loop substeps for push, PR updates, checks, base refresh, merge,
+merge confirmation, merge recovery, and cleanup. Extensions can also replace
+named PR-loop policies and register commands under `pid x ...`. See
+[docs/EXTENSIONS.md](docs/EXTENSIONS.md) for the API, trust boundary, and
+runnable local-extension examples.
 
 Prompt templates must be non-blank and support these fields:
 

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -89,6 +89,36 @@ replace these extension-aware steps:
 16. `commit_changes`
 17. `run_pr_loop`
 
+`run_pr_loop` is itself split into hookable/replaceable substeps:
+
+1. `pr_prepare_attempt`
+2. `pr_refresh_base_before_message`
+3. `pr_regenerate_message`
+4. `pr_refresh_base_before_pr`
+5. `pr_push_branch`
+6. `pr_ensure_pr`
+7. `pr_wait_for_checks`
+8. `pr_handle_checks`
+9. `pr_refresh_base_after_checks`
+10. `pr_squash_merge`
+11. `pr_recover_merge`
+12. `pr_confirm_merge`
+13. `pr_cleanup`
+
+PR-loop policy names are `pr.push`, `pr.ensure_pr`, `pr.checks`, `pr.ci_fix`,
+`pr.base_refresh`, `pr.merge`, `pr.merge_recovery`, `pr.merge_confirmation`, and
+`pr.cleanup`. Register a callable with `registry.add_policy(name, fn)` to replace
+one behavior while keeping surrounding hooks and loop control. Policy callables
+receive `WorkflowContext` and return `None` or `StepResult`; replacements should
+update the same context fields as the default policy, such as `ctx.checks_status`
+/ `ctx.checks_output`, `ctx.pr_loop.refresh_result`,
+`ctx.pr_loop.merge_result`, or `ctx.pr_loop.merge_confirmed`. Replacements that
+short-circuit terminal substeps must set either `ctx.pr_loop.completed` or
+`ctx.pr_loop.next_iteration`; otherwise pid reports an extension error instead
+of looping forever. If `pr_cleanup` is disabled or skipped after merge
+confirmation, pid treats the PR loop as complete and leaves cleanup to the
+extension or operator.
+
 Entry-point extensions load earlier and can also replace or disable bootstrap
 steps, but local extensions intentionally cannot change argument parsing or repo
 resolution.
@@ -112,6 +142,9 @@ Hooks and steps receive `WorkflowContext`. Common fields:
 - `ctx.forge`
 - `ctx.events`
 - `ctx.scratch`
+- `ctx.pr_loop` for PR-loop state such as `need_force_push`,
+  `refresh_result`, `checks_timeout_seconds`, `merge_result`,
+  `merge_confirmed`, `next_iteration`, and `completed`
 
 Useful helpers:
 

--- a/src/pid/context.py
+++ b/src/pid/context.py
@@ -12,9 +12,28 @@ from pid.events import EventSink, NullEventSink, WorkflowEvent
 from pid.extensions import ExtensionRegistry
 from pid.github import Forge
 from pid.keepawake import KeepAwake
-from pid.models import CommitMessage, OutputMode, ParsedArgs
+from pid.models import CommandResult, CommitMessage, OutputMode, ParsedArgs
 from pid.repository import Repository
 from pid.session_logging import SessionLogger
+
+
+@dataclass
+class PRLoopState:
+    """Mutable state for fine-grained PR-loop extension points."""
+
+    need_force_push: bool = False
+    message_state_hash: str = ""
+    refresh_stage: str = ""
+    refresh_result: str = ""
+    refreshed_before_message: bool = False
+    checks_timeout_seconds: int = 0
+    checks_poll_interval_seconds: int = 0
+    merge_retry_limit: int = 0
+    merge_result: CommandResult | None = None
+    pr_head_oid: str = ""
+    merge_confirmed: bool = False
+    next_iteration: bool = False
+    completed: bool = False
 
 
 @dataclass
@@ -58,6 +77,7 @@ class WorkflowContext:
     services: dict[str, Any] = field(default_factory=dict)
     scratch: dict[str, Any] = field(default_factory=dict)
     step_retries: dict[str, int] = field(default_factory=dict)
+    pr_loop: PRLoopState = field(default_factory=PRLoopState)
 
     @property
     def extension_config(self) -> dict[str, dict[str, Any]]:

--- a/src/pid/extensions.py
+++ b/src/pid/extensions.py
@@ -206,13 +206,16 @@ class ExtensionRegistry:
         default_steps: Iterable[WorkflowStep],
         *,
         known_steps: Iterable[str] = (),
+        external_steps: Iterable[str] = (),
+        include_unanchored: bool = True,
     ) -> list[WorkflowStep]:
         """Return default steps after applying extension modifications."""
 
         steps = list(default_steps)
         self._validate_unique_steps(steps)
         default_names = {step.name for step in steps}
-        known_step_names = set(known_steps)
+        external_step_names = set(external_steps)
+        known_step_names = set(known_steps) | external_step_names
         missing_replacements = (
             set(self.replaced_steps) - default_names - known_step_names
         )
@@ -235,6 +238,8 @@ class ExtensionRegistry:
             if insertion.step.name in names:
                 raise ExtensionError(f"step already registered: {insertion.step.name}")
             if insertion.before is not None:
+                if insertion.before in external_step_names:
+                    continue
                 if insertion.before not in names:
                     raise ExtensionError(
                         f"cannot add step before unknown step: {insertion.before}"
@@ -242,13 +247,16 @@ class ExtensionRegistry:
                 resolved.insert(names.index(insertion.before), insertion.step)
                 continue
             if insertion.after is not None:
+                if insertion.after in external_step_names:
+                    continue
                 if insertion.after not in names:
                     raise ExtensionError(
                         f"cannot add step after unknown step: {insertion.after}"
                     )
                 resolved.insert(names.index(insertion.after) + 1, insertion.step)
                 continue
-            resolved.append(insertion.step)
+            if include_unanchored:
+                resolved.append(insertion.step)
 
         self._validate_unique_steps(resolved)
         return resolved

--- a/src/pid/workflow.py
+++ b/src/pid/workflow.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import shutil
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 from pid.commands import CommandRunner, require_command
 from pid.config import PIDConfig
-from pid.context import WorkflowContext
+from pid.context import PRLoopState, WorkflowContext
 from pid.errors import PIDAbort, abort
 from pid.events import EventSink, NullEventSink
 from pid.extensions import (
@@ -138,6 +139,7 @@ class PIDFlow:
             for step in self.registry.resolve_steps(
                 self.default_steps(),
                 known_steps=(step.name for step in bootstrap_steps),
+                external_steps=self.pr_loop_step_names(),
             ):
                 self.run_workflow_step(ctx, step)
             ctx.emit("workflow.completed")
@@ -186,6 +188,38 @@ class PIDFlow:
             WorkflowStep("commit_changes", self.step_commit_changes),
             WorkflowStep("run_pr_loop", self.step_run_pr_loop),
         ]
+
+    def default_pr_loop_steps(self) -> list[WorkflowStep]:
+        """Return extension-aware PR-loop substeps."""
+
+        return [
+            WorkflowStep("pr_prepare_attempt", self.step_pr_prepare_attempt),
+            WorkflowStep(
+                "pr_refresh_base_before_message",
+                self.step_pr_refresh_base_before_message,
+            ),
+            WorkflowStep("pr_regenerate_message", self.step_pr_regenerate_message),
+            WorkflowStep(
+                "pr_refresh_base_before_pr", self.step_pr_refresh_base_before_pr
+            ),
+            WorkflowStep("pr_push_branch", self.step_pr_push_branch),
+            WorkflowStep("pr_ensure_pr", self.step_pr_ensure_pr),
+            WorkflowStep("pr_wait_for_checks", self.step_pr_wait_for_checks),
+            WorkflowStep("pr_handle_checks", self.step_pr_handle_checks),
+            WorkflowStep(
+                "pr_refresh_base_after_checks",
+                self.step_pr_refresh_base_after_checks,
+            ),
+            WorkflowStep("pr_squash_merge", self.step_pr_squash_merge),
+            WorkflowStep("pr_recover_merge", self.step_pr_recover_merge),
+            WorkflowStep("pr_confirm_merge", self.step_pr_confirm_merge),
+            WorkflowStep("pr_cleanup", self.step_pr_cleanup),
+        ]
+
+    def pr_loop_step_names(self) -> tuple[str, ...]:
+        """Return known PR-loop substep names for extension validation."""
+
+        return tuple(step.name for step in self.default_pr_loop_steps())
 
     def run_workflow_step(self, ctx: WorkflowContext, step: WorkflowStep) -> None:
         """Run one step with hooks, events, replacements, and bounded retry."""
@@ -464,17 +498,7 @@ class PIDFlow:
     def step_run_pr_loop(self, ctx: WorkflowContext) -> None:
         if ctx.commit_message is None:
             raise RuntimeError("commit message has not been generated")
-        self.run_pr_loop(
-            parsed=ctx.require_parsed(),
-            base_rev=ctx.base_rev,
-            commit_message=ctx.commit_message,
-            commit_title=ctx.commit_title,
-            rewritten_head=ctx.rewritten_head,
-            followup_thinking_level=ctx.followup_thinking_level,
-            main_worktree=ctx.main_worktree,
-            default_branch=ctx.default_branch,
-            worktree_path=ctx.worktree_path,
-        )
+        self.run_pr_loop(ctx)
 
     def start_session_logging(self, argv: list[str]) -> None:
         """Create and announce the per-run session log."""
@@ -566,284 +590,393 @@ class PIDFlow:
             f"pid: {self.config.forge.executable} is required for PR creation",
         )
 
-    def run_pr_loop(
-        self,
-        *,
-        parsed: ParsedArgs,
-        base_rev: str,
-        commit_message: CommitMessage,
-        commit_title: str,
-        rewritten_head: str,
-        followup_thinking_level: str,
-        main_worktree: str,
-        default_branch: str,
-        worktree_path: str,
-    ) -> None:
-        need_force_push = False
-        pr_url = ""
-        message_state_hash = self.repository.state_hash(worktree_path)
-        base_refresh_count = 0
-        base_refresh_stage_counts: dict[str, int] = {}
-        checks_timeout_seconds = env_int(
-            "PID_CHECKS_TIMEOUT_SECONDS", self.config.workflow.checks_timeout_seconds
+    def run_pr_loop(self, ctx: WorkflowContext) -> None:
+        """Run the extension-aware PR attempt loop."""
+
+        parsed = ctx.require_parsed()
+        ctx.pr_loop = PRLoopState(
+            message_state_hash=self.repository.state_hash(ctx.worktree_path),
+            checks_timeout_seconds=env_int(
+                "PID_CHECKS_TIMEOUT_SECONDS",
+                self.config.workflow.checks_timeout_seconds,
+            ),
+            checks_poll_interval_seconds=env_int(
+                "PID_CHECKS_POLL_INTERVAL_SECONDS",
+                self.config.workflow.checks_poll_interval_seconds,
+            ),
+            merge_retry_limit=env_int(
+                "PID_MERGE_RETRY_LIMIT", self.config.workflow.merge_retry_limit
+            ),
         )
-        checks_poll_interval_seconds = env_int(
-            "PID_CHECKS_POLL_INTERVAL_SECONDS",
-            self.config.workflow.checks_poll_interval_seconds,
+        ctx.base_refresh_count = 0
+        ctx.base_refresh_stage_counts = {}
+        ctx.merge_retries = 0
+        ctx.attempt = 1
+
+        pr_loop_steps = self.registry.resolve_steps(
+            self.default_pr_loop_steps(),
+            external_steps=(
+                *(step.name for step in self.bootstrap_steps()),
+                *(step.name for step in self.default_steps()),
+            ),
+            include_unanchored=False,
         )
-        merge_retry_limit = env_int(
-            "PID_MERGE_RETRY_LIMIT", self.config.workflow.merge_retry_limit
-        )
-        merge_retries = 0
-        attempt = 1
 
-        while attempt <= parsed.max_attempts:
-            if self.session_logger is not None:
-                self.session_logger.separator(
-                    f"PR ATTEMPT {attempt}/{parsed.max_attempts}"
-                )
-            print_attempt_header(attempt, parsed.max_attempts)
-            echo_out(f"pid: PR attempt {attempt}/{parsed.max_attempts}")
-            commit_title = self.repository.commit_dirty_automated_feedback(
-                worktree_path,
-                commit_title,
-                self.config.commit.automated_feedback_title,
-            )
-            refresh_result, base_refresh_count = self.refresh_base_if_needed(
-                stage="before_message",
-                base_refresh_count=base_refresh_count,
-                stage_counts=base_refresh_stage_counts,
-                default_branch=default_branch,
-                original_prompt=parsed.prompt,
-                pr_title=commit_message.title,
-                pr_body=commit_message.body,
-                pr_url=pr_url or "(not opened yet)",
-                commit_title=commit_title,
-                followup_thinking_level=followup_thinking_level,
-                worktree_path=worktree_path,
-            )
-            self.abort_on_stopped_base_refresh(refresh_result, "before message")
-            refreshed_before_message = refresh_result in REFRESH_REBASE_RESULTS
-            if refreshed_before_message:
-                need_force_push = True
-                commit_title = self.repository.commit_rebase_changes(
-                    worktree_path,
-                    commit_title,
-                    self.config.commit.rebase_feedback_title,
-                )
-            current_state_hash = self.repository.state_hash(worktree_path)
-            if refreshed_before_message or current_state_hash != message_state_hash:
-                commit_message, message_state_hash = self.regenerate_commit_message(
-                    parsed=parsed,
-                    base_rev=base_rev,
-                    worktree_path=worktree_path,
-                )
-
-            refresh_result, base_refresh_count = self.refresh_base_if_needed(
-                stage="before_pr",
-                base_refresh_count=base_refresh_count,
-                stage_counts=base_refresh_stage_counts,
-                default_branch=default_branch,
-                original_prompt=parsed.prompt,
-                pr_title=commit_message.title,
-                pr_body=commit_message.body,
-                pr_url=pr_url or "(not opened yet)",
-                commit_title=commit_title,
-                followup_thinking_level=followup_thinking_level,
-                worktree_path=worktree_path,
-            )
-            self.abort_on_stopped_base_refresh(refresh_result, "before PR push")
-            if refresh_result in REFRESH_REBASE_RESULTS:
-                need_force_push = True
-                commit_title = self.repository.commit_rebase_changes(
-                    worktree_path,
-                    commit_title,
-                    self.config.commit.rebase_feedback_title,
-                )
-                commit_message, message_state_hash = self.regenerate_commit_message(
-                    parsed=parsed,
-                    base_rev=base_rev,
-                    worktree_path=worktree_path,
-                )
-
-            self.push_pr_branch(
-                branch=parsed.branch,
-                worktree_path=worktree_path,
-                force=need_force_push,
-                rewritten_head=rewritten_head,
-            )
-            need_force_push = False
-
-            self.forge.ensure_pr(parsed.branch, commit_message, worktree_path)
-            pr_title = commit_message.title
-            pr_url = self.forge.pr_url(parsed.branch, worktree_path)
-
-            checks_status, checks_out = self.forge.wait_for_checks(
-                parsed.branch,
-                checks_timeout_seconds,
-                checks_poll_interval_seconds,
-                worktree_path,
-            )
-            if has_output(checks_out) and (
-                checks_status != 0 or not self.runner.writes_success_output()
-            ):
-                write_collected(checks_out, stream=sys.stdout)
-            if checks_status != 0:
-                if self.forge.output_reports_no_checks(checks_out):
-                    echo_out("pid: no CI checks reported; continuing")
-                elif attempt >= parsed.max_attempts:
-                    echo_err(
-                        f"pid: CI checks failed after {attempt} attempts; "
-                        f"leaving PR open: {pr_url}"
-                    )
-                    abort(checks_status)
-                else:
-                    followup_thinking_level = self.fix_ci_failures(
-                        pr_title=pr_title,
-                        pr_url=pr_url,
-                        commit_title=commit_title,
-                        checks_out=checks_out,
-                        followup_thinking_level=followup_thinking_level,
-                        worktree_path=worktree_path,
-                    )
-                    attempt += 1
-                    merge_retries = 0
-                    continue
-
-            refresh_result, base_refresh_count = self.refresh_base_if_needed(
-                stage="after_checks",
-                base_refresh_count=base_refresh_count,
-                stage_counts=base_refresh_stage_counts,
-                default_branch=default_branch,
-                original_prompt=parsed.prompt,
-                pr_title=pr_title,
-                pr_body=commit_message.body,
-                pr_url=pr_url,
-                commit_title=commit_title,
-                followup_thinking_level=followup_thinking_level,
-                worktree_path=worktree_path,
-            )
-            self.abort_on_stopped_base_refresh(refresh_result, "after checks")
-            if refresh_result in REFRESH_REBASE_RESULTS:
-                commit_title = self.repository.commit_rebase_changes(
-                    worktree_path,
-                    commit_title,
-                    self.config.commit.rebase_feedback_title,
-                )
-                commit_message, message_state_hash = self.regenerate_commit_message(
-                    parsed=parsed,
-                    base_rev=base_rev,
-                    worktree_path=worktree_path,
-                )
-                self.runner.require(
-                    [
-                        "git",
-                        "push",
-                        "--force-with-lease",
-                        "-u",
-                        "origin",
-                        parsed.branch,
-                    ],
-                    cwd=worktree_path,
-                )
-                self.forge.ensure_pr(parsed.branch, commit_message, worktree_path)
-                merge_retries = 0
+        while ctx.attempt <= parsed.max_attempts:
+            ctx.pr_loop.next_iteration = False
+            ctx.pr_loop.merge_result = None
+            ctx.pr_loop.pr_head_oid = ""
+            ctx.pr_loop.merge_confirmed = False
+            ctx.pr_loop.refreshed_before_message = False
+            ctx.pr_loop.refresh_stage = ""
+            ctx.pr_loop.refresh_result = ""
+            ctx.checks_status = 0
+            ctx.checks_output = ""
+            for step in pr_loop_steps:
+                self.run_workflow_step(ctx, step)
+                if ctx.pr_loop.completed:
+                    return
+                if ctx.pr_loop.next_iteration:
+                    break
+            if ctx.pr_loop.completed:
+                return
+            if ctx.pr_loop.merge_confirmed:
+                ctx.pr_loop.completed = True
+                return
+            if ctx.pr_loop.next_iteration:
                 continue
-
-            pr_head_oid = ""
-            if self.config.forge.merge_uses_head_oid:
-                pr_head_oid = self.forge.head_oid(parsed.branch, worktree_path)
-            merge_result = self.forge.squash_merge(
-                parsed.branch,
-                pr_head_oid,
-                commit_message,
-                pr_url,
-                worktree_path,
+            raise ExtensionError(
+                "PR loop did not complete or request another iteration; "
+                "PR-loop step replacements must set ctx.pr_loop.completed or "
+                "ctx.pr_loop.next_iteration, or leave terminal substeps enabled"
             )
-            if has_output(merge_result.stdout) and (
-                merge_result.returncode != 0 or not self.runner.writes_success_output()
-            ):
-                write_collected(merge_result.stdout, stream=sys.stdout)
-
-            if merge_result.returncode == 0:
-                self.finish_successful_merge(
-                    pr_url=pr_url,
-                    pr_title=pr_title,
-                    main_worktree=main_worktree,
-                    default_branch=default_branch,
-                    branch=parsed.branch,
-                    worktree_path=worktree_path,
-                )
-                return
-
-            if self.forge.reports_merged(pr_url, worktree_path):
-                echo_out(
-                    f"pid: {self.config.forge.label} reports PR merged despite "
-                    "local forge cleanup failure; cleaning up"
-                )
-                self.cleanup_and_print_success(
-                    pr_url=pr_url,
-                    pr_title=pr_title,
-                    main_worktree=main_worktree,
-                    default_branch=default_branch,
-                    branch=parsed.branch,
-                    worktree_path=worktree_path,
-                )
-                return
-
-            merge_retries += 1
-            if merge_retries > merge_retry_limit:
-                echo_err(
-                    f"pid: {self.config.forge.label} squash merge failed after "
-                    f"{merge_retry_limit} merge retries; leaving PR open: {pr_url}"
-                )
-                abort(merge_result.returncode)
-
-            echo_out(
-                "pid: merge failed; rebasing onto latest "
-                f"origin/{default_branch} before retry "
-                f"({merge_retries}/{merge_retry_limit} merge retries; "
-                "agent attempts unchanged)"
-            )
-            self.runner.require(
-                ["git", "fetch", "origin", default_branch], cwd=worktree_path
-            )
-
-            rebase_result = self.runner.run(
-                ["git", "rebase", f"origin/{default_branch}"], cwd=worktree_path
-            )
-            if rebase_result.returncode != 0:
-                write_command_output(rebase_result)
-                followup_thinking_level = self.fix_rebase(
-                    original_prompt=parsed.prompt,
-                    pr_title=pr_title,
-                    pr_body=commit_message.body,
-                    pr_url=pr_url,
-                    default_branch=default_branch,
-                    commit_title=commit_title,
-                    merge_out=command_diagnostics(merge_result, rebase_result),
-                    followup_thinking_level=followup_thinking_level,
-                    worktree_path=worktree_path,
-                )
-
-            if self.repository.rebase_in_progress(worktree_path):
-                echo_err(
-                    "pid: rebase still in progress after agent; "
-                    f"leaving PR open: {pr_url}"
-                )
-                abort(1)
-
-            commit_title = self.repository.commit_rebase_changes(
-                worktree_path,
-                commit_title,
-                self.config.commit.rebase_feedback_title,
-            )
-            need_force_push = True
 
         echo_err(
-            f"pid: exhausted {parsed.max_attempts} attempts; leaving worktree: {worktree_path}"
+            "pid: exhausted "
+            f"{parsed.max_attempts} attempts; leaving worktree: {ctx.worktree_path}"
         )
         abort(1)
+
+    def run_policy(
+        self,
+        ctx: WorkflowContext,
+        name: str,
+        default: Callable[[WorkflowContext], StepResult | None],
+    ) -> None:
+        """Run a replaceable policy callback."""
+
+        policy = ctx.registry.policies.get(name, default)
+        handler = policy if callable(policy) else getattr(policy, "run", None)
+        if not callable(handler):
+            raise ExtensionError(f"policy {name} must be callable or expose run(ctx)")
+        try:
+            result = normalize_step_result(handler(ctx))
+        except ExtensionError, PIDAbort:
+            raise
+        except Exception as error:
+            raise ExtensionError(
+                f"policy {name} failed: {type(error).__name__}: {error}"
+            ) from error
+        self.handle_step_result(result)
+
+    def step_pr_prepare_attempt(self, ctx: WorkflowContext) -> None:
+        parsed = ctx.require_parsed()
+        if self.session_logger is not None:
+            self.session_logger.separator(
+                f"PR ATTEMPT {ctx.attempt}/{parsed.max_attempts}"
+            )
+        print_attempt_header(ctx.attempt, parsed.max_attempts)
+        echo_out(f"pid: PR attempt {ctx.attempt}/{parsed.max_attempts}")
+        ctx.commit_title = self.repository.commit_dirty_automated_feedback(
+            ctx.worktree_path,
+            ctx.commit_title,
+            self.config.commit.automated_feedback_title,
+        )
+
+    def step_pr_refresh_base_before_message(self, ctx: WorkflowContext) -> None:
+        self.run_base_refresh_step(ctx, "before_message", "before message")
+        ctx.pr_loop.refreshed_before_message = (
+            ctx.pr_loop.refresh_result in REFRESH_REBASE_RESULTS
+        )
+        if ctx.pr_loop.refreshed_before_message:
+            ctx.pr_loop.need_force_push = True
+            ctx.commit_title = self.repository.commit_rebase_changes(
+                ctx.worktree_path,
+                ctx.commit_title,
+                self.config.commit.rebase_feedback_title,
+            )
+
+    def step_pr_regenerate_message(self, ctx: WorkflowContext) -> None:
+        current_state_hash = self.repository.state_hash(ctx.worktree_path)
+        if (
+            not ctx.pr_loop.refreshed_before_message
+            and current_state_hash == ctx.pr_loop.message_state_hash
+        ):
+            return
+        self.regenerate_context_message(ctx)
+
+    def step_pr_refresh_base_before_pr(self, ctx: WorkflowContext) -> None:
+        self.run_base_refresh_step(ctx, "before_pr", "before PR push")
+        if ctx.pr_loop.refresh_result not in REFRESH_REBASE_RESULTS:
+            return
+        ctx.pr_loop.need_force_push = True
+        ctx.commit_title = self.repository.commit_rebase_changes(
+            ctx.worktree_path,
+            ctx.commit_title,
+            self.config.commit.rebase_feedback_title,
+        )
+        self.regenerate_context_message(ctx)
+
+    def step_pr_push_branch(self, ctx: WorkflowContext) -> None:
+        self.run_policy(ctx, "pr.push", self.policy_pr_push_branch)
+        ctx.pr_loop.need_force_push = False
+
+    def step_pr_ensure_pr(self, ctx: WorkflowContext) -> None:
+        self.run_policy(ctx, "pr.ensure_pr", self.policy_pr_ensure_pr)
+
+    def step_pr_wait_for_checks(self, ctx: WorkflowContext) -> None:
+        self.run_policy(ctx, "pr.checks", self.policy_pr_checks)
+
+    def step_pr_handle_checks(self, ctx: WorkflowContext) -> None:
+        parsed = ctx.require_parsed()
+        if ctx.checks_status == 0:
+            return
+        if self.forge.output_reports_no_checks(ctx.checks_output):
+            echo_out("pid: no CI checks reported; continuing")
+            return
+        if ctx.attempt >= parsed.max_attempts:
+            echo_err(
+                f"pid: CI checks failed after {ctx.attempt} attempts; "
+                f"leaving PR open: {ctx.pr_url}"
+            )
+            abort(ctx.checks_status)
+        self.run_policy(ctx, "pr.ci_fix", self.policy_pr_ci_fix)
+        ctx.attempt += 1
+        ctx.merge_retries = 0
+        ctx.pr_loop.next_iteration = True
+
+    def step_pr_refresh_base_after_checks(self, ctx: WorkflowContext) -> None:
+        self.run_base_refresh_step(ctx, "after_checks", "after checks")
+        if ctx.pr_loop.refresh_result not in REFRESH_REBASE_RESULTS:
+            return
+        ctx.commit_title = self.repository.commit_rebase_changes(
+            ctx.worktree_path,
+            ctx.commit_title,
+            self.config.commit.rebase_feedback_title,
+        )
+        self.regenerate_context_message(ctx)
+        ctx.pr_loop.need_force_push = True
+        self.run_workflow_step(
+            ctx, WorkflowStep("pr_push_branch", self.step_pr_push_branch)
+        )
+        self.run_workflow_step(
+            ctx, WorkflowStep("pr_ensure_pr", self.step_pr_ensure_pr)
+        )
+        ctx.merge_retries = 0
+        ctx.pr_loop.next_iteration = True
+
+    def step_pr_squash_merge(self, ctx: WorkflowContext) -> None:
+        self.run_policy(ctx, "pr.merge", self.policy_pr_merge)
+
+    def step_pr_recover_merge(self, ctx: WorkflowContext) -> None:
+        merge_result = ctx.pr_loop.merge_result
+        if merge_result is None or merge_result.returncode == 0:
+            return
+        self.run_policy(ctx, "pr.merge_recovery", self.policy_pr_merge_recovery)
+
+    def step_pr_confirm_merge(self, ctx: WorkflowContext) -> None:
+        if ctx.pr_loop.merge_confirmed:
+            return
+        merge_result = ctx.pr_loop.merge_result
+        if merge_result is None or merge_result.returncode != 0:
+            return
+        self.run_policy(
+            ctx,
+            "pr.merge_confirmation",
+            self.policy_pr_merge_confirmation,
+        )
+
+    def step_pr_cleanup(self, ctx: WorkflowContext) -> None:
+        if not ctx.pr_loop.merge_confirmed:
+            return
+        self.run_policy(ctx, "pr.cleanup", self.policy_pr_cleanup)
+        ctx.pr_loop.completed = True
+
+    def run_base_refresh_step(
+        self, ctx: WorkflowContext, stage: str, stopped_label: str
+    ) -> None:
+        ctx.pr_loop.refresh_stage = stage
+        ctx.pr_loop.refresh_result = "unchanged"
+        self.run_policy(ctx, "pr.base_refresh", self.policy_pr_base_refresh)
+        self.abort_on_stopped_base_refresh(ctx.pr_loop.refresh_result, stopped_label)
+
+    def regenerate_context_message(self, ctx: WorkflowContext) -> None:
+        commit_message, message_state_hash = self.regenerate_commit_message(
+            parsed=ctx.require_parsed(),
+            base_rev=ctx.base_rev,
+            worktree_path=ctx.worktree_path,
+        )
+        ctx.set_commit_message(commit_message)
+        ctx.pr_loop.message_state_hash = message_state_hash
+
+    def policy_pr_base_refresh(self, ctx: WorkflowContext) -> None:
+        if ctx.commit_message is None:
+            raise RuntimeError("commit message has not been generated")
+        refresh_result, ctx.base_refresh_count = self.refresh_base_if_needed(
+            stage=ctx.pr_loop.refresh_stage,
+            base_refresh_count=ctx.base_refresh_count,
+            stage_counts=ctx.base_refresh_stage_counts,
+            default_branch=ctx.default_branch,
+            original_prompt=ctx.require_parsed().prompt,
+            pr_title=ctx.commit_message.title,
+            pr_body=ctx.commit_message.body,
+            pr_url=ctx.pr_url or "(not opened yet)",
+            commit_title=ctx.commit_title,
+            followup_thinking_level=ctx.followup_thinking_level,
+            worktree_path=ctx.worktree_path,
+        )
+        ctx.pr_loop.refresh_result = refresh_result
+
+    def policy_pr_push_branch(self, ctx: WorkflowContext) -> None:
+        self.push_pr_branch(
+            branch=ctx.require_parsed().branch,
+            worktree_path=ctx.worktree_path,
+            force=ctx.pr_loop.need_force_push,
+            rewritten_head=ctx.rewritten_head,
+        )
+
+    def policy_pr_ensure_pr(self, ctx: WorkflowContext) -> None:
+        if ctx.commit_message is None:
+            raise RuntimeError("commit message has not been generated")
+        parsed = ctx.require_parsed()
+        self.forge.ensure_pr(parsed.branch, ctx.commit_message, ctx.worktree_path)
+        ctx.pr_title = ctx.commit_message.title
+        ctx.pr_url = self.forge.pr_url(parsed.branch, ctx.worktree_path)
+
+    def policy_pr_checks(self, ctx: WorkflowContext) -> None:
+        ctx.checks_status, ctx.checks_output = self.forge.wait_for_checks(
+            ctx.require_parsed().branch,
+            ctx.pr_loop.checks_timeout_seconds,
+            ctx.pr_loop.checks_poll_interval_seconds,
+            ctx.worktree_path,
+        )
+        if has_output(ctx.checks_output) and (
+            ctx.checks_status != 0 or not self.runner.writes_success_output()
+        ):
+            write_collected(ctx.checks_output, stream=sys.stdout)
+
+    def policy_pr_ci_fix(self, ctx: WorkflowContext) -> None:
+        ctx.followup_thinking_level = self.fix_ci_failures(
+            pr_title=ctx.pr_title,
+            pr_url=ctx.pr_url,
+            commit_title=ctx.commit_title,
+            checks_out=ctx.checks_output,
+            followup_thinking_level=ctx.followup_thinking_level,
+            worktree_path=ctx.worktree_path,
+        )
+
+    def policy_pr_merge(self, ctx: WorkflowContext) -> None:
+        if ctx.commit_message is None:
+            raise RuntimeError("commit message has not been generated")
+        ctx.pr_loop.pr_head_oid = ""
+        if self.config.forge.merge_uses_head_oid:
+            ctx.pr_loop.pr_head_oid = self.forge.head_oid(
+                ctx.require_parsed().branch, ctx.worktree_path
+            )
+        ctx.pr_loop.merge_result = self.forge.squash_merge(
+            ctx.require_parsed().branch,
+            ctx.pr_loop.pr_head_oid,
+            ctx.commit_message,
+            ctx.pr_url,
+            ctx.worktree_path,
+        )
+        if has_output(ctx.pr_loop.merge_result.stdout) and (
+            ctx.pr_loop.merge_result.returncode != 0
+            or not self.runner.writes_success_output()
+        ):
+            write_collected(ctx.pr_loop.merge_result.stdout, stream=sys.stdout)
+
+    def policy_pr_merge_recovery(self, ctx: WorkflowContext) -> None:
+        merge_result = ctx.pr_loop.merge_result
+        if merge_result is None:
+            raise RuntimeError("merge result is not available")
+        if self.forge.reports_merged(ctx.pr_url, ctx.worktree_path):
+            echo_out(
+                f"pid: {self.config.forge.label} reports PR merged despite "
+                "local forge cleanup failure; cleaning up"
+            )
+            ctx.pr_loop.merge_confirmed = True
+            return
+
+        ctx.merge_retries += 1
+        if ctx.merge_retries > ctx.pr_loop.merge_retry_limit:
+            echo_err(
+                f"pid: {self.config.forge.label} squash merge failed after "
+                f"{ctx.pr_loop.merge_retry_limit} merge retries; "
+                f"leaving PR open: {ctx.pr_url}"
+            )
+            abort(merge_result.returncode)
+
+        echo_out(
+            "pid: merge failed; rebasing onto latest "
+            f"origin/{ctx.default_branch} before retry "
+            f"({ctx.merge_retries}/{ctx.pr_loop.merge_retry_limit} merge retries; "
+            "agent attempts unchanged)"
+        )
+        self.runner.require(
+            ["git", "fetch", "origin", ctx.default_branch], cwd=ctx.worktree_path
+        )
+
+        rebase_result = self.runner.run(
+            ["git", "rebase", f"origin/{ctx.default_branch}"], cwd=ctx.worktree_path
+        )
+        if rebase_result.returncode != 0:
+            write_command_output(rebase_result)
+            if ctx.commit_message is None:
+                raise RuntimeError("commit message has not been generated")
+            ctx.followup_thinking_level = self.fix_rebase(
+                original_prompt=ctx.require_parsed().prompt,
+                pr_title=ctx.pr_title,
+                pr_body=ctx.commit_message.body,
+                pr_url=ctx.pr_url,
+                default_branch=ctx.default_branch,
+                commit_title=ctx.commit_title,
+                merge_out=command_diagnostics(merge_result, rebase_result),
+                followup_thinking_level=ctx.followup_thinking_level,
+                worktree_path=ctx.worktree_path,
+            )
+
+        if self.repository.rebase_in_progress(ctx.worktree_path):
+            echo_err(
+                "pid: rebase still in progress after agent; "
+                f"leaving PR open: {ctx.pr_url}"
+            )
+            abort(1)
+
+        ctx.commit_title = self.repository.commit_rebase_changes(
+            ctx.worktree_path,
+            ctx.commit_title,
+            self.config.commit.rebase_feedback_title,
+        )
+        ctx.pr_loop.need_force_push = True
+        ctx.pr_loop.next_iteration = True
+
+    def policy_pr_merge_confirmation(self, ctx: WorkflowContext) -> None:
+        if not self.wait_for_confirmed_merge(
+            pr_url=ctx.pr_url, worktree_path=ctx.worktree_path
+        ):
+            abort(1)
+        ctx.pr_loop.merge_confirmed = True
+
+    def policy_pr_cleanup(self, ctx: WorkflowContext) -> None:
+        self.cleanup_and_print_success(
+            pr_url=ctx.pr_url,
+            pr_title=ctx.pr_title,
+            main_worktree=ctx.main_worktree,
+            default_branch=ctx.default_branch,
+            branch=ctx.require_parsed().branch,
+            worktree_path=ctx.worktree_path,
+        )
 
     def regenerate_commit_message(
         self, *, parsed: ParsedArgs, base_rev: str, worktree_path: str

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -14,7 +14,7 @@ from pid.errors import PIDAbort
 from pid.extensions import ExtensionError, ExtensionRegistry, StepResult, WorkflowStep
 from pid.models import CommandResult
 from pid.workflow import PIDFlow, command_diagnostic
-from tests.fakes import assert_success, base_state, run_pid
+from tests.fakes import assert_success, base_state, calls, run_pid
 
 
 DEMO_EXTENSION = "\n".join(
@@ -152,6 +152,207 @@ paths = ["{extension_dir}"]
         "initial",
         "message",
     ]
+
+
+def test_project_local_extension_can_replace_pr_loop_substep(
+    tmp_path: Path,
+) -> None:
+    extension_dir = tmp_path / "extensions"
+    extension_dir.mkdir()
+    (extension_dir / "pr_steps.py").write_text(
+        "\n".join(
+            [
+                "from pid.output import echo_out",
+                "",
+                "def before_checks(ctx):",
+                "    echo_out('extension before PR checks')",
+                "",
+                "def skip_checks(ctx):",
+                "    ctx.checks_status = 0",
+                "    ctx.checks_output = 'extension skipped checks'",
+                "",
+                "class PrStepsExtension:",
+                "    name = 'pr_steps'",
+                "    api_version = '1'",
+                "    def register(self, registry):",
+                "        registry.add_hook('before.pr_wait_for_checks', before_checks)",
+                "        registry.replace_step('pr_wait_for_checks', skip_checks)",
+                "",
+                "extension = PrStepsExtension()",
+                "",
+            ]
+        )
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f"""
+[extensions]
+enabled = ["pr_steps"]
+paths = ["{extension_dir}"]
+""".strip()
+    )
+    state = base_state(
+        tmp_path,
+        checks_sequence=[{"status": 1, "out": "unit tests failed"}],
+    )
+
+    process, final_state = run_pid(
+        tmp_path,
+        ["--config", str(config_path), "feature/cool-stuff", "prompt"],
+        state=state,
+    )
+
+    assert_success(process)
+    assert "extension before PR checks" in process.stdout
+    assert not calls(final_state, "gh", "pr", "checks")
+    assert not [call for call in final_state["pi_calls"] if call["kind"] == "ci_fix"]
+
+
+def test_project_local_extension_can_replace_pr_loop_policy(
+    tmp_path: Path,
+) -> None:
+    extension_dir = tmp_path / "extensions"
+    extension_dir.mkdir()
+    (extension_dir / "pr_policy.py").write_text(
+        "\n".join(
+            [
+                "def checks_policy(ctx):",
+                "    ctx.checks_status = 0",
+                "    ctx.checks_output = 'policy checks passed'",
+                "",
+                "class PrPolicyExtension:",
+                "    name = 'pr_policy'",
+                "    api_version = '1'",
+                "    def register(self, registry):",
+                "        registry.add_policy('pr.checks', checks_policy)",
+                "",
+                "extension = PrPolicyExtension()",
+                "",
+            ]
+        )
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f"""
+[extensions]
+enabled = ["pr_policy"]
+paths = ["{extension_dir}"]
+""".strip()
+    )
+    state = base_state(
+        tmp_path,
+        checks_sequence=[{"status": 1, "out": "unit tests failed"}],
+    )
+
+    process, final_state = run_pid(
+        tmp_path,
+        ["--config", str(config_path), "feature/cool-stuff", "prompt"],
+        state=state,
+    )
+
+    assert_success(process)
+    assert not calls(final_state, "gh", "pr", "checks")
+    assert not [call for call in final_state["pi_calls"] if call["kind"] == "ci_fix"]
+
+
+def test_registry_routes_steps_anchored_to_external_phases() -> None:
+    registry = ExtensionRegistry()
+    registry.add_step(WorkflowStep("top_extra", lambda _ctx: None), after="run_pr_loop")
+    registry.add_step(
+        WorkflowStep("pr_extra", lambda _ctx: None), after="pr_push_branch"
+    )
+
+    top_steps = registry.resolve_steps(
+        [WorkflowStep("run_pr_loop", lambda _ctx: None)],
+        external_steps=("pr_push_branch",),
+    )
+    pr_steps = registry.resolve_steps(
+        [WorkflowStep("pr_push_branch", lambda _ctx: None)],
+        external_steps=("run_pr_loop",),
+        include_unanchored=False,
+    )
+
+    assert [step.name for step in top_steps] == ["run_pr_loop", "top_extra"]
+    assert [step.name for step in pr_steps] == ["pr_push_branch", "pr_extra"]
+
+
+def test_project_local_extension_can_disable_pr_cleanup_without_looping(
+    tmp_path: Path,
+) -> None:
+    extension_dir = tmp_path / "extensions"
+    extension_dir.mkdir()
+    (extension_dir / "no_cleanup.py").write_text(
+        "\n".join(
+            [
+                "class NoCleanupExtension:",
+                "    name = 'no_cleanup'",
+                "    api_version = '1'",
+                "    def register(self, registry):",
+                "        registry.disable_step('pr_cleanup')",
+                "",
+                "extension = NoCleanupExtension()",
+                "",
+            ]
+        )
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f"""
+[extensions]
+enabled = ["no_cleanup"]
+paths = ["{extension_dir}"]
+""".strip()
+    )
+
+    process, final_state = run_pid(
+        tmp_path,
+        ["--config", str(config_path), "feature/cool-stuff", "prompt"],
+    )
+
+    assert_success(process)
+    assert final_state["merged_at_queries"] == 1
+    assert not calls(final_state, "git", "worktree", "remove")
+    assert not calls(final_state, "git", "branch", "-D")
+    assert not [
+        call for call in calls(final_state, "git", "push") if "--delete" in call["args"]
+    ]
+
+
+def test_project_local_extension_terminal_pr_loop_misconfiguration_errors(
+    tmp_path: Path,
+) -> None:
+    extension_dir = tmp_path / "extensions"
+    extension_dir.mkdir()
+    (extension_dir / "no_merge.py").write_text(
+        "\n".join(
+            [
+                "class NoMergeExtension:",
+                "    name = 'no_merge'",
+                "    api_version = '1'",
+                "    def register(self, registry):",
+                "        registry.disable_step('pr_squash_merge')",
+                "",
+                "extension = NoMergeExtension()",
+                "",
+            ]
+        )
+    )
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f"""
+[extensions]
+enabled = ["no_merge"]
+paths = ["{extension_dir}"]
+""".strip()
+    )
+
+    process, _ = run_pid(
+        tmp_path,
+        ["--config", str(config_path), "feature/cool-stuff", "prompt"],
+    )
+
+    assert process.returncode == 2
+    assert "PR loop did not complete or request another iteration" in process.stderr
 
 
 def test_pid_x_dispatches_project_local_extension_command(tmp_path: Path) -> None:


### PR DESCRIPTION
- Split the PR loop into hookable/replaceable substeps backed by shared PRLoopState on WorkflowContext.
- Added named PR-loop policies for push, PR creation, checks, CI fixes, base refresh, merge, confirmation, recovery, and cleanup.
- Scoped extension step resolution across top-level and PR-loop phases, with safeguards for terminal PR-loop replacements and disabled cleanup.
- Updated README/extension docs and tests for substeps, policy overrides, scoped routing, cleanup opt-out, and misconfiguration errors.