### PR TITLE
refactor(code): simplify internal workflows

### DIFF
--- a/src/pid/extensions.py
+++ b/src/pid/extensions.py
@@ -213,53 +213,96 @@ class ExtensionRegistry:
 
         steps = list(default_steps)
         self._validate_unique_steps(steps)
-        default_names = {step.name for step in steps}
+
         external_step_names = set(external_steps)
-        known_step_names = set(known_steps) | external_step_names
-        missing_replacements = (
-            set(self.replaced_steps) - default_names - known_step_names
+        self._validate_replacements(
+            default_names={step.name for step in steps},
+            known_names=set(known_steps) | external_step_names,
         )
+
+        resolved = self._active_default_steps(steps)
+        for insertion in sorted(
+            self.added_steps, key=lambda item: item.registration_index
+        ):
+            self._apply_step_insertion(
+                resolved,
+                insertion,
+                external_step_names=external_step_names,
+                include_unanchored=include_unanchored,
+            )
+
+        self._validate_unique_steps(resolved)
+        return resolved
+
+    def _validate_replacements(
+        self, *, default_names: set[str], known_names: set[str]
+    ) -> None:
+        missing_replacements = set(self.replaced_steps) - default_names - known_names
         if missing_replacements:
             missing = sorted(missing_replacements)[0]
             raise ExtensionError(f"cannot replace unknown step: {missing}")
 
-        resolved: list[WorkflowStep] = []
-        for step in steps:
-            if step.name in self.disabled_steps:
-                continue
-            resolved.append(self.replaced_steps.get(step.name, step))
+    def _active_default_steps(self, steps: list[WorkflowStep]) -> list[WorkflowStep]:
+        return [
+            self.replaced_steps.get(step.name, step)
+            for step in steps
+            if step.name not in self.disabled_steps
+        ]
 
-        for insertion in sorted(
-            self.added_steps, key=lambda item: item.registration_index
-        ):
-            if insertion.step.name in self.disabled_steps:
-                continue
-            names = [step.name for step in resolved]
-            if insertion.step.name in names:
-                raise ExtensionError(f"step already registered: {insertion.step.name}")
-            if insertion.before is not None:
-                if insertion.before in external_step_names:
-                    continue
-                if insertion.before not in names:
-                    raise ExtensionError(
-                        f"cannot add step before unknown step: {insertion.before}"
-                    )
-                resolved.insert(names.index(insertion.before), insertion.step)
-                continue
-            if insertion.after is not None:
-                if insertion.after in external_step_names:
-                    continue
-                if insertion.after not in names:
-                    raise ExtensionError(
-                        f"cannot add step after unknown step: {insertion.after}"
-                    )
-                resolved.insert(names.index(insertion.after) + 1, insertion.step)
-                continue
-            if include_unanchored:
-                resolved.append(insertion.step)
+    def _apply_step_insertion(
+        self,
+        resolved: list[WorkflowStep],
+        insertion: _StepInsertion,
+        *,
+        external_step_names: set[str],
+        include_unanchored: bool,
+    ) -> None:
+        if insertion.step.name in self.disabled_steps:
+            return
 
-        self._validate_unique_steps(resolved)
-        return resolved
+        names = [step.name for step in resolved]
+        if insertion.step.name in names:
+            raise ExtensionError(f"step already registered: {insertion.step.name}")
+        if insertion.before is not None:
+            self._insert_step(
+                resolved,
+                insertion.step,
+                anchor=insertion.before,
+                names=names,
+                external_step_names=external_step_names,
+                after=False,
+            )
+            return
+        if insertion.after is not None:
+            self._insert_step(
+                resolved,
+                insertion.step,
+                anchor=insertion.after,
+                names=names,
+                external_step_names=external_step_names,
+                after=True,
+            )
+            return
+        if include_unanchored:
+            resolved.append(insertion.step)
+
+    @staticmethod
+    def _insert_step(
+        resolved: list[WorkflowStep],
+        step: WorkflowStep,
+        *,
+        anchor: str,
+        names: list[str],
+        external_step_names: set[str],
+        after: bool,
+    ) -> None:
+        if anchor in external_step_names:
+            return
+        direction = "after" if after else "before"
+        if anchor not in names:
+            raise ExtensionError(f"cannot add step {direction} unknown step: {anchor}")
+        offset = 1 if after else 0
+        resolved.insert(names.index(anchor) + offset, step)
 
     def run_hooks(self, name: str, ctx: Any) -> StepResult:
         """Run registered hooks and return the first non-continue result."""

--- a/src/pid/orchestrator.py
+++ b/src/pid/orchestrator.py
@@ -148,34 +148,11 @@ class OrchestratorAgent:
         except WorkflowFailure as failure:
             self.store.update_from_context(run_id, flow.context)
             action = self.policy.decide(failure)
-            if action.kind == RecoveryActionKind.MARK_DONE:
-                state = self.store.mark_failed(
-                    run_id,
-                    failure,
-                    pending_recovery_action=action.to_dict(),
-                    status="no_changes",
-                )
-                return AgentRunResult(run_id, state, failure.code)
-            if failure.kind == FailureKind.FOLLOWUP_PAUSED:
-                state = self.store.mark_failed(
-                    run_id,
-                    failure,
-                    pending_recovery_action=action.to_dict(),
-                    status="paused",
-                )
-                return AgentRunResult(run_id, state, failure.code)
-            if failure.kind == FailureKind.FOLLOWUP_ABORTED:
-                state = self.store.mark_failed(
-                    run_id,
-                    failure,
-                    pending_recovery_action=action.to_dict(),
-                    status="aborted",
-                )
-                return AgentRunResult(run_id, state, failure.code)
             state = self.store.mark_failed(
                 run_id,
                 failure,
                 pending_recovery_action=action.to_dict(),
+                status=agent_failure_status(failure, action.kind),
             )
             return AgentRunResult(run_id, state, failure.code)
         state = self.store.mark_succeeded(run_id, ctx)
@@ -238,27 +215,12 @@ class OrchestratorSupervisor:
             branch_prefix=branch_prefix,
             config=self.config,
         )
-        for child in children:
-            self.store.create_run(
-                branch=str(child["branch"]),
-                prompt=str(child["prompt"]),
-                argv=workflow_argv(
-                    AgentStartOptions(
-                        branch=str(child["branch"]),
-                        prompt=str(child["prompt"]),
-                        thinking=str(child["thinking"]),
-                        run_id=str(child["child_run_id"]),
-                        parent_run_id=run_id,
-                        plan_item_id=str(child["item_id"]),
-                    ),
-                    default_thinking=self.config.agent.default_thinking,
-                ),
-                run_id=str(child["child_run_id"]),
-                parent_run_id=run_id,
-                plan_item_id=str(child["item_id"]),
-                status="planned",
-                extra={"thinking": child["thinking"]},
-            )
+        create_planned_child_runs(
+            self.store,
+            children,
+            parent_run_id=run_id,
+            default_thinking=self.config.agent.default_thinking,
+        )
 
         state["children"] = children
         state["status"] = "planned" if options.dry_run else "running"
@@ -332,6 +294,55 @@ class OrchestratorSupervisor:
         )
         self.store.write_state(options.run_id, state)
         return {"record": record, "routed_to": delivered}
+
+
+def agent_failure_status(
+    failure: WorkflowFailure, action_kind: RecoveryActionKind
+) -> str:
+    """Return persisted run status for a supervised workflow failure."""
+
+    if action_kind == RecoveryActionKind.MARK_DONE:
+        return "no_changes"
+    if failure.kind == FailureKind.FOLLOWUP_PAUSED:
+        return "paused"
+    if failure.kind == FailureKind.FOLLOWUP_ABORTED:
+        return "aborted"
+    return "failed"
+
+
+def create_planned_child_runs(
+    store: RunStore,
+    children: list[dict[str, Any]],
+    *,
+    parent_run_id: str,
+    default_thinking: str,
+) -> None:
+    """Persist planned child runs before they are launched."""
+
+    for child in children:
+        branch = str(child["branch"])
+        prompt = str(child["prompt"])
+        thinking = str(child["thinking"])
+        child_run_id = str(child["child_run_id"])
+        item_id = str(child["item_id"])
+        options = AgentStartOptions(
+            branch=branch,
+            prompt=prompt,
+            thinking=thinking,
+            run_id=child_run_id,
+            parent_run_id=parent_run_id,
+            plan_item_id=item_id,
+        )
+        store.create_run(
+            branch=branch,
+            prompt=prompt,
+            argv=workflow_argv(options, default_thinking=default_thinking),
+            run_id=child_run_id,
+            parent_run_id=parent_run_id,
+            plan_item_id=item_id,
+            status="planned",
+            extra={"thinking": thinking},
+        )
 
 
 def workflow_argv(options: AgentStartOptions, *, default_thinking: str) -> list[str]:

--- a/src/pid/session_logging.py
+++ b/src/pid/session_logging.py
@@ -45,9 +45,10 @@ def session_log_dir(
     if override := env.get(LOG_DIR_ENV):
         return Path(override).expanduser()
 
-    if xdg_state_home := env.get("XDG_STATE_HOME"):
-        if xdg_path := _absolute_env_path(xdg_state_home):
-            return xdg_path / "pid" / "logs"
+    if (xdg_state_home := env.get("XDG_STATE_HOME")) and (
+        xdg_path := _absolute_env_path(xdg_state_home)
+    ):
+        return xdg_path / "pid" / "logs"
 
     base_home = Path.home() if home is None else home
     system = platform.system() if platform_name is None else platform_name

--- a/src/pid/workflow.py
+++ b/src/pid/workflow.py
@@ -415,7 +415,7 @@ class PIDFlow:
     def handle_step_result(result: StepResult) -> None:
         """Apply a step or hook result."""
 
-        if result.action == "continue" or result.action == "skip":
+        if result.action in {"continue", "skip"}:
             return
         if result.action == "stop":
             abort(result.code)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -609,7 +609,7 @@ def _args_for_workflow_tests(args: list[str]) -> list[str]:
         if value in options_with_values:
             index += 2
             continue
-        if value.startswith("--config=") or value.startswith("--output="):
+        if value.startswith(("--config=", "--output=")):
             index += 1
             continue
         if value.startswith("-"):


### PR DESCRIPTION
# Pull Request

## Summary

- Simplify extension step resolution into smaller validation/insertion helpers.
- Consolidate orchestrator failure-status mapping and planned child-run persistence.
- Clean up a few small readability patterns in session logging, workflow result handling, and workflow-test fakes.

## Linked issue

Related to #62

## Type

- [ ] fix
- [ ] feat
- [ ] docs
- [x] refactor
- [x] test
- [ ] chore

## Validation

- [x] `mise run check`
- [ ] Other: <!-- command or reason not run -->

## Notes for reviewer

Behavior-preserving refactor only; no user-facing behavior changes intended.
